### PR TITLE
Ensure mobile menu overlay covers full screen height

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,9 +21,11 @@
     .animate-rise { animation: rise .8s ease-out both }
     .price-section table { width:100%; table-layout:fixed; }
     .price-section th, .price-section td { width:33.333%; }
+    .vh-100 { height:100vh; height:100lvh; }
+    .min-vh-100 { min-height:100vh; min-height:100lvh; }
   </style>
 </head>
-<body class="min-h-full bg-neutral-950 text-neutral-100 antialiased">
+<body class="bg-neutral-950 text-neutral-100 antialiased min-vh-100">
   <!-- Header / Nav -->
   <header class="sticky top-0 z-40 backdrop-blur bg-neutral-950/70 border-b border-white/10">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
@@ -50,7 +52,7 @@
   </header>
 
   <!-- Mobile menu -->
-  <div id="mobileMenu" class="fixed inset-0 z-40 hidden">
+  <div id="mobileMenu" class="fixed inset-x-0 top-0 z-40 hidden vh-100">
     <div id="menuOverlay" class="absolute inset-0 bg-black/50 backdrop-blur-sm"></div>
     <nav id="menuPanel" class="absolute top-0 right-0 h-full w-3/5 max-w-xs bg-neutral-950 p-6 transform translate-x-full transition-transform duration-300">
       <button id="menuClose" class="absolute top-4 right-4 p-2" aria-label="Close menu">


### PR DESCRIPTION
## Summary
- Add helper classes that use `lvh` units for full viewport coverage on iOS Safari
- Apply new classes to body and mobile menu to extend blurred overlay beneath Safari toolbar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b85d4afc80832489eae6393843e12e