### PR TITLE
Add logo icons and WhatsApp contact option

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,10 @@
   <!-- Header / Nav -->
   <header class="sticky top-0 z-40 backdrop-blur bg-neutral-950/70 border-b border-white/10">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
-      <a href="#home" class="font-extrabold tracking-tight text-xl">RD9 Automotive</a>
+      <a href="#home" class="flex items-center">
+        <img src="RD9-simple-white.svg" alt="RD9 Automotive logo" class="h-8 w-auto">
+        <span class="sr-only">RD9 Automotive</span>
+      </a>
       <nav aria-label="Primary" class="hidden md:block">
         <ul class="flex gap-8 text-sm">
           <li><a class="hover:opacity-80" href="#services">Services</a></li>
@@ -579,6 +582,7 @@
             <p><span class="font-semibold text-neutral-100">Hours:</span><br>8am – 5pm, Monday to Saturday</p>
             <p><span class="font-semibold text-neutral-100">Email:</span> <a class="underline hover:no-underline" href="mailto:info@rd9.co.uk">info@RD9.co.uk</a></p>
             <p><span class="font-semibold text-neutral-100">Phone:</span> <a class="underline hover:no-underline" href="tel:+447915211671">+44 (0) 7915 211 671</a></p>
+            <p><span class="font-semibold text-neutral-100">WhatsApp:</span> <a class="inline-flex items-center gap-2 underline hover:no-underline" href="https://wa.me/+447915211671"><img src="IMG_6457.png" alt="WhatsApp logo" class="h-5 w-5">Message us</a></p>
           </div>
         </div>
         <div>
@@ -600,9 +604,12 @@
           </form>
         </div>
       </div>
-      <div class="mt-12 text-xs text-neutral-500">© RD9 2024.</div>
-    </div>
-  </section>
+        <div class="mt-12 flex items-center gap-2 text-xs text-neutral-500">
+          <img src="RD9-simple-white.svg" alt="RD9 Automotive logo" class="h-6 w-auto">
+          <span>© RD9 2024.</span>
+        </div>
+      </div>
+    </section>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
   <script>


### PR DESCRIPTION
## Summary
- Display RD9 logo SVG in navigation and footer
- Add WhatsApp contact link using existing icon asset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b867b937dc8324ab58c19b21f711f4