### PR TITLE
Simplify branding on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,13 +26,12 @@
     :root { --brand: rgb(255,215,0); }
     .text-brand { color: var(--brand); }
     .bg-brand { background-color: var(--brand); }
-    .border-brand { border-color: var(--brand); }
     nav a:hover { color: var(--brand); }
   </style>
 </head>
 <body class="bg-neutral-950 text-neutral-100 antialiased min-vh-100">
   <!-- Header / Nav -->
-  <header class="sticky top-0 z-40 backdrop-blur bg-neutral-950/70 border-b border-brand">
+  <header class="sticky top-0 z-40 backdrop-blur bg-neutral-950/70 border-b border-white/10">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
       <a href="#home" class="flex items-center">
         <img src="RD9-simple-white.svg" alt="RD9 Automotive logo" class="h-8 w-auto">
@@ -82,7 +81,7 @@
     <div class="absolute inset-0 bg-gradient-to-br from-neutral-900 via-neutral-950 to-black"></div>
     <div class="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-24 sm:py-28 lg:py-36">
       <div class="max-w-3xl animate-rise">
-        <h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold tracking-tight text-brand">The Gold Standard</h1>
+        <h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold tracking-tight text-white">The <span class="text-brand">Gold</span> Standard</h1>
         <p class="mt-6 text-lg text-neutral-300">
           Welcome to RD9 Automotive, Porsche and Prestige vehicle specialists. We feel that, for too long, the motor trade has fallen short, and we are here to change that.
           From a prized possession to your everyday vehicle, we are here to maintain, repair and modify your vehicles to the highest of standards.
@@ -93,17 +92,17 @@
         </p>
         <div class="mt-10 flex flex-wrap items-center gap-4">
           <a href="#prices" class="rounded-md bg-brand text-neutral-900 px-5 py-3 font-semibold hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/60">View Prices</a>
-          <a href="#about" class="px-5 py-3 font-semibold border border-brand text-brand rounded-md hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-white/40">About RD9</a>
+          <a href="#about" class="px-5 py-3 font-semibold border border-white/20 text-white rounded-md hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-white/40">About RD9</a>
         </div>
       </div>
     </div>
   </section>
 
   <!-- Services — blurbs -->
-  <section id="services" class="bg-neutral-900/60 border-t border-brand">
+  <section id="services" class="bg-neutral-900/60 border-t border-white/10">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
       <header class="max-w-3xl">
-        <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-brand">Services</h2>
+        <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-white">Services</h2>
         <p class="mt-3 text-neutral-300">High-end care with main-dealer tooling, delivered with a personal touch.</p>
       </header>
 
@@ -137,10 +136,10 @@
   </section>
 
   <!-- Prices -->
-  <section id="prices" class="bg-neutral-900/60 border-t border-brand">
+  <section id="prices" class="bg-neutral-900/60 border-t border-white/10">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
       <header class="max-w-3xl">
-        <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-brand">Prices</h2>
+        <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-white">Prices</h2>
         <p class="mt-3 text-neutral-300">Fixed-price servicing across popular models.</p>
       </header>
 
@@ -569,9 +568,9 @@
   </section>
 
   <!-- About -->
-  <section id="about" class="border-t border-brand bg-neutral-900/50">
+  <section id="about" class="border-t border-white/10 bg-neutral-900/50">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
-      <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-brand">About</h2>
+      <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-white">About</h2>
       <div class="mt-6 max-w-3xl space-y-4 text-neutral-300">
         <p><strong>The Gold Standard</strong><br>RD9 was founded in 2020 by Ryan Day. Ryan started his career at Porsche back in 2007 where he went through his apprenticeship all the way to achieving the gold certification in 2018. Over the last year he’s been venturing into other prestigious manufactures from lotus to Lamborghini. Now his goal is to take what he thinks works from the main dealers and add the personal touch that’s much needed.</p>
       </div>
@@ -579,9 +578,9 @@
   </section>
 
   <!-- Contact -->
-  <section id="contact" class="border-t border-brand">
+  <section id="contact" class="border-t border-white/10">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
-      <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-brand">Contact us</h2>
+      <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-white">Contact us</h2>
       <div class="mt-8 grid lg:grid-cols-2 gap-10">
         <div>
           <div class="space-y-3 text-neutral-300">


### PR DESCRIPTION
## Summary
- Remove gold section dividers and revert headings to white
- Highlight the word "Gold" in the hero CTA while keeping other elements neutral

## Testing
- `npx htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b9696229ec8324beec188ae63637c9