### PR TITLE
Prefill contact form with mailto template

### DIFF
--- a/index.html
+++ b/index.html
@@ -602,21 +602,29 @@
           </div>
         </div>
         <div>
-          <form class="rounded-lg border border-white/10 p-6 bg-neutral-900 space-y-4" aria-label="Enquiry form (static)">
-            <p class="text-sm text-neutral-400">This is a static demo form. Replace with your preferred form endpoint/service.</p>
+          <form id="contactForm" class="rounded-lg border border-white/10 p-6 bg-neutral-900 space-y-4" aria-label="Enquiry form">
+            <p class="text-sm text-neutral-400">Fields marked * are required.</p>
             <div>
               <label for="name" class="block text-sm font-medium">Name</label>
               <input id="name" name="name" type="text" class="mt-2 w-full rounded-md bg-neutral-950 border border-white/15 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-white/30" />
             </div>
             <div>
-              <label for="email" class="block text-sm font-medium">Email</label>
-              <input id="email" name="email" type="email" class="mt-2 w-full rounded-md bg-neutral-950 border border-white/15 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-white/30" />
+              <label for="carModel" class="block text-sm font-medium">Car model *</label>
+              <input id="carModel" name="carModel" list="carOptions" required class="mt-2 w-full rounded-md bg-neutral-950 border border-white/15 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-white/30" />
+            </div>
+            <div>
+              <label for="email" class="block text-sm font-medium">Email *</label>
+              <input id="email" name="email" type="email" required class="mt-2 w-full rounded-md bg-neutral-950 border border-white/15 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-white/30" />
+            </div>
+            <div>
+              <label for="phone" class="block text-sm font-medium">Contact number *</label>
+              <input id="phone" name="phone" type="tel" required class="mt-2 w-full rounded-md bg-neutral-950 border border-white/15 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-white/30" />
             </div>
             <div>
               <label for="message" class="block text-sm font-medium">Message</label>
               <textarea id="message" name="message" rows="4" class="mt-2 w-full rounded-md bg-neutral-950 border border-white/15 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-white/30"></textarea>
             </div>
-            <button type="button" class="inline-flex items-center gap-2 rounded-md bg-white text-neutral-900 px-4 py-2 text-sm font-semibold hover:bg-neutral-200 focus:outline-none focus:ring-2 focus:ring-white/50">Send</button>
+            <button type="submit" class="inline-flex items-center gap-2 rounded-md bg-white text-neutral-900 px-4 py-2 text-sm font-semibold hover:bg-neutral-200 focus:outline-none focus:ring-2 focus:ring-white/50">Send</button>
           </form>
         </div>
       </div>
@@ -626,6 +634,25 @@
         </div>
       </div>
     </section>
+
+  <script>
+    (function () {
+      const form = document.getElementById('contactForm');
+      form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        const name = document.getElementById('name').value.trim();
+        const car = document.getElementById('carModel').value.trim();
+        const email = document.getElementById('email').value.trim();
+        const phone = document.getElementById('phone').value.trim();
+        const message = document.getElementById('message').value.trim();
+        const subject = encodeURIComponent(`Enquiry: ${car}`);
+        let body = `Car model: ${car}\nEmail: ${email}\nContact number: ${phone}`;
+        if (name) body = `Name: ${name}\n` + body;
+        if (message) body += `\n\n${message}`;
+        window.location.href = `mailto:info@rd9.co.uk?subject=${subject}&body=${encodeURIComponent(body)}`;
+      });
+    })();
+  </script>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
   <script>


### PR DESCRIPTION
## Summary
- require car model, email, and contact number on contact form
- submit form via a pre-filled mailto link

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b96e36eb5c8324ad35c181ee36022c