### PR TITLE
Fix mobile header button order and menu height

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,20 +56,20 @@
         </ul>
       </nav>
       <div class="flex items-center gap-4">
+        <a href="#contact" class="inline-flex items-center gap-2 rounded-md bg-brand text-neutral-900 px-3 py-2 text-sm font-medium hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/50">
+          Book / Enquire
+        </a>
         <button id="menuOpen" class="md:hidden p-2" aria-label="Open menu">
           <svg class="h-6 w-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
           </svg>
         </button>
-        <a href="#contact" class="inline-flex items-center gap-2 rounded-md bg-brand text-neutral-900 px-3 py-2 text-sm font-medium hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/50">
-          Book / Enquire
-        </a>
       </div>
     </div>
   </header>
 
   <!-- Mobile menu -->
-  <div id="mobileMenu" class="fixed inset-0 z-40 hidden">
+  <div id="mobileMenu" class="fixed inset-0 z-40 hidden" style="bottom:calc(-1 * env(safe-area-inset-bottom))">
     <div id="menuOverlay" class="absolute inset-0 bg-black/50 backdrop-blur-sm"></div>
     <nav id="menuPanel" class="absolute top-0 right-0 h-full w-3/5 max-w-xs bg-neutral-950 p-6 transform translate-x-full transition-transform duration-300">
       <button id="menuClose" class="absolute top-4 right-4 p-2" aria-label="Close menu">


### PR DESCRIPTION
## Summary
- Reorder mobile header actions so the Book/Enquire button comes before the menu toggle
- Extend the mobile menu overlay beyond the safe-area inset to cover Safari's bottom toolbar

## Testing
- `npx prettier --check index.html` *(fails: code style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b98059f4008324b57ff5eb19e0c5c9