### PR TITLE
Increase tyre tread background visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
   <!-- Hero -->
   <section id="home" class="relative">
     <div class="absolute inset-0 bg-gradient-to-br from-neutral-900 via-neutral-950 to-black pointer-events-none"></div>
-    <div class="absolute inset-0 opacity-10 bg-[url('tyre-tread.svg')] bg-repeat pointer-events-none"></div>
+    <div class="absolute inset-0 opacity-20 bg-[url('tyre-tread.svg')] bg-repeat pointer-events-none"></div>
     <div class="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-24 sm:py-28 lg:py-36">
       <div class="max-w-3xl animate-rise">
         <h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold tracking-tight text-white">The <span class="text-brand">Gold</span> Standard</h1>

--- a/tyre-tread.svg
+++ b/tyre-tread.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none">
   <defs>
     <linearGradient id="grad" x1="0" y1="0" x2="20" y2="20" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#222"/>
-      <stop offset="1" stop-color="#111"/>
+      <stop offset="0" stop-color="#555"/>
+      <stop offset="1" stop-color="#333"/>
     </linearGradient>
   </defs>
   <path d="M-5 20L15 0" stroke="url(#grad)" stroke-width="4" stroke-linecap="square"/>


### PR DESCRIPTION
## Summary
- Lighten tyre tread pattern gradient for clearer contrast
- Increase overlay opacity so background effect is noticeable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b986370098832497c6fee3f8475c9a