### PR TITLE
Ensure #home link scrolls to top

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     }
   </style>
 </head>
-<body class="bg-neutral-950 text-neutral-100 antialiased min-vh-100">
+<body id="home" class="bg-neutral-950 text-neutral-100 antialiased min-vh-100">
   <!-- Header / Nav -->
   <header class="sticky top-0 z-40 backdrop-blur bg-neutral-950/70 border-b border-white/10">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
@@ -87,7 +87,7 @@
   </div>
 
   <!-- Hero -->
-  <section id="home" class="relative">
+  <section class="relative">
     <div class="absolute inset-0 bg-gradient-to-br from-neutral-900 via-neutral-950 to-black pointer-events-none"></div>
     <div class="absolute inset-0 opacity-20 bg-[url('tyre-tread.svg')] bg-repeat pointer-events-none"></div>
     <div class="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-24 sm:py-28 lg:py-36">


### PR DESCRIPTION
## Summary
- Move `home` identifier to `<body>` so `/#home` anchors jump to the very top of the page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b988b3af8083249edfa373138ef8c3