### PR TITLE
feat: add interactive service details

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,37 +117,62 @@
         <p class="mt-3 text-neutral-300">High-end care with main-dealer tooling, delivered with a personal touch.</p>
       </header>
 
-      <div class="mt-10 grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        <article class="rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20">
-          <img src="icons/porsche-servicing.svg" alt="" class="h-10 w-10 mb-4" />
-          <h3 class="font-semibold text-lg">Porsche Servicing</h3>
-          <p class="mt-2 text-sm text-neutral-300">We offer a wide range of servicing and repairs… genuine Porsche parts… or the very best of the aftermarket.</p>
-        </article>
-        <article class="rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20">
-          <img src="icons/performance.svg" alt="" class="h-10 w-10 mb-4" />
-          <h3 class="font-semibold text-lg">Performance</h3>
-          <p class="mt-2 text-sm text-neutral-300">Unlock the full potential of your vehicle… tuning options… package deal with one of our performance maps.</p>
-        </article>
-        <article class="rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20">
-          <img src="icons/prestige.svg" alt="" class="h-10 w-10 mb-4" />
-          <h3 class="font-semibold text-lg">Prestige</h3>
-          <p class="mt-2 text-sm text-neutral-300">We understand that your luxury vehicle demands nothing but the best…</p>
-        </article>
-        <article class="rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20">
-          <img src="icons/electric-hybrid.svg" alt="" class="h-10 w-10 mb-4" />
-          <h3 class="font-semibold text-lg">Electric & Hybrid</h3>
-          <p class="mt-2 text-sm text-neutral-300">We offer fully qualified High Voltage technicians…</p>
-        </article>
-        <article class="rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20">
-          <img src="icons/wheel-alignment.svg" alt="" class="h-10 w-10 mb-4" />
-          <h3 class="font-semibold text-lg">Wheel Alignment</h3>
-          <p class="mt-2 text-sm text-neutral-300">Suspension alignments are a critical aspect of vehicle maintenance…</p>
-        </article>
-        <article class="rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20">
-          <img src="icons/pre-purchase.svg" alt="" class="h-10 w-10 mb-4" />
-          <h3 class="font-semibold text-lg">Pre-Purchase Inspections</h3>
-          <p class="mt-2 text-sm text-neutral-300">A pre-purchase Inspection gives you a more in-depth understanding of what you’re buying…</p>
-        </article>
+      <div id="servicesPanel" class="mt-10 lg:flex lg:gap-8">
+        <ul id="serviceList" class="space-y-4 lg:w-1/3">
+          <li>
+            <button type="button" class="service-card w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="porsche-servicing" data-url="https://www.rd9.co.uk/porsche-servicing">
+              <img src="icons/porsche-servicing.svg" alt="" class="h-10 w-10 mb-4" />
+              <h3 class="font-semibold text-lg">Porsche Servicing</h3>
+              <p class="mt-2 text-sm text-neutral-300">We offer a wide range of servicing and repairs… genuine Porsche parts… or the very best of the aftermarket.</p>
+            </button>
+            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"></div>
+          </li>
+          <li>
+            <button type="button" class="service-card w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="performance" data-url="https://www.rd9.co.uk/performance">
+              <img src="icons/performance.svg" alt="" class="h-10 w-10 mb-4" />
+              <h3 class="font-semibold text-lg">Performance</h3>
+              <p class="mt-2 text-sm text-neutral-300">Unlock the full potential of your vehicle… tuning options… package deal with one of our performance maps.</p>
+            </button>
+            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"></div>
+          </li>
+          <li>
+            <button type="button" class="service-card w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="prestige" data-url="https://www.rd9.co.uk/prestige">
+              <img src="icons/prestige.svg" alt="" class="h-10 w-10 mb-4" />
+              <h3 class="font-semibold text-lg">Prestige</h3>
+              <p class="mt-2 text-sm text-neutral-300">We understand that your luxury vehicle demands nothing but the best…</p>
+            </button>
+            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"></div>
+          </li>
+          <li>
+            <button type="button" class="service-card w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="electric-hybrid" data-url="https://www.rd9.co.uk/electric-hybrid">
+              <img src="icons/electric-hybrid.svg" alt="" class="h-10 w-10 mb-4" />
+              <h3 class="font-semibold text-lg">Electric & Hybrid</h3>
+              <p class="mt-2 text-sm text-neutral-300">We offer fully qualified High Voltage technicians…</p>
+            </button>
+            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"></div>
+          </li>
+          <li>
+            <button type="button" class="service-card w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="wheel-alignment" data-url="https://www.rd9.co.uk/wheel-alignment">
+              <img src="icons/wheel-alignment.svg" alt="" class="h-10 w-10 mb-4" />
+              <h3 class="font-semibold text-lg">Wheel Alignment</h3>
+              <p class="mt-2 text-sm text-neutral-300">Suspension alignments are a critical aspect of vehicle maintenance…</p>
+            </button>
+            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"></div>
+          </li>
+          <li>
+            <button type="button" class="service-card w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="pre-purchase-inspections" data-url="https://www.rd9.co.uk/pre-purchase-inspections">
+              <img src="icons/pre-purchase.svg" alt="" class="h-10 w-10 mb-4" />
+              <h3 class="font-semibold text-lg">Pre-Purchase Inspections</h3>
+              <p class="mt-2 text-sm text-neutral-300">A pre-purchase Inspection gives you a more in-depth understanding of what you’re buying…</p>
+            </button>
+            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"></div>
+          </li>
+        </ul>
+        <div id="serviceDetail" class="mt-6 hidden lg:block lg:w-2/3">
+          <div id="serviceContent" class="p-6 rounded-lg border border-white/10 bg-neutral-900 text-neutral-200">
+            <p>Select a service to learn more.</p>
+          </div>
+        </div>
       </div>
     </div>
   </section>
@@ -849,27 +874,83 @@
           clearSelection();
         }
       });
-    })();
-  </script>
+      })();
+    </script>
 
-  <script>
-    (function () {
-      const section = document.getElementById('services');
-      if (!section) return;
-      const cards = section.querySelectorAll('article');
-      const observer = new IntersectionObserver((entries) => {
-        if (entries[0].isIntersecting) {
-          cards.forEach((card, i) => {
-            card.style.animationDelay = `${i * 100}ms`;
-            card.classList.add('animate-rise');
-            card.classList.remove('opacity-0');
-          });
-          observer.disconnect();
+    <script>
+      (function () {
+        const list = document.getElementById('serviceList');
+        const detailPanel = document.getElementById('serviceDetail');
+        const detailContent = document.getElementById('serviceContent');
+        if (!list) return;
+
+        function isDesktop() {
+          return window.matchMedia('(min-width: 1024px)').matches;
         }
-      }, { threshold: 0.2 });
-      observer.observe(section);
-    })();
-  </script>
+
+        function clearActive() {
+          list.querySelectorAll('.service-card').forEach(btn => {
+            btn.classList.remove('ring-2', 'ring-white/40');
+          });
+        }
+
+        function closeDetails() {
+          list.querySelectorAll('.service-details').forEach(d => d.classList.add('hidden'));
+        }
+
+        async function loadService(btn) {
+          const url = btn.dataset.url;
+          try {
+            const html = await fetch(url).then(r => r.text());
+            const doc = new DOMParser().parseFromString(html, 'text/html');
+            const main = doc.querySelector('main') || doc.body;
+            return main.innerHTML;
+          } catch (e) {
+            return '<p class="text-sm text-red-400">Failed to load service details.</p>';
+          }
+        }
+
+        list.querySelectorAll('.service-card').forEach(btn => {
+          btn.addEventListener('click', async () => {
+            const parentLi = btn.parentElement;
+            const details = parentLi.querySelector('.service-details');
+            clearActive();
+            btn.classList.add('ring-2', 'ring-white/40');
+            if (isDesktop()) {
+              detailPanel.classList.remove('hidden');
+              detailContent.innerHTML = '<p class="text-sm text-neutral-300">Loading…</p>';
+              detailContent.innerHTML = await loadService(btn);
+            } else {
+              closeDetails();
+              detailContent.innerHTML = '';
+              details.innerHTML = '<p class="text-sm text-neutral-300">Loading…</p>';
+              details.classList.remove('hidden');
+              details.innerHTML = await loadService(btn);
+              parentLi.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+          });
+        });
+      })();
+    </script>
+
+    <script>
+      (function () {
+        const section = document.getElementById('services');
+        if (!section) return;
+        const cards = section.querySelectorAll('.service-card');
+        const observer = new IntersectionObserver((entries) => {
+          if (entries[0].isIntersecting) {
+            cards.forEach((card, i) => {
+              card.style.animationDelay = `${i * 100}ms`;
+              card.classList.add('animate-rise');
+              card.classList.remove('opacity-0');
+            });
+            observer.disconnect();
+          }
+        }, { threshold: 0.2 });
+        observer.observe(section);
+      })();
+    </script>
 
   <script>
     (function () {


### PR DESCRIPTION
## Summary
- Replace static service cards with a list and responsive detail panel
- Fetch service information from rd9.co.uk when items are selected
- Mobile accordion expands one service at a time and scrolls into view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b98afaf03c8324925725e20411912f