### PR TITLE
Add photo to About section

### DIFF
--- a/index.html
+++ b/index.html
@@ -591,6 +591,9 @@
       <div class="mt-6 max-w-3xl space-y-4 text-neutral-300">
         <p><strong>The Gold Standard</strong><br>RD9 was founded in 2020 by Ryan Day. Ryan started his career at Porsche back in 2007 where he went through his apprenticeship all the way to achieving the gold certification in 2018. Over the last year he’s been venturing into other prestigious manufactures from lotus to Lamborghini. Now his goal is to take what he thinks works from the main dealers and add the personal touch that’s much needed.</p>
       </div>
+      <div class="mt-10">
+        <img src="66e04639cc2cc749eb6111c2_62eaa221af55929f9612ef9a_Untitled.jpeg" alt="RD9 workshop" class="rounded-lg shadow-lg mx-auto" />
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Display workshop photo in the About section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b98d7d50008324896ba045df5f7e3f