### PR TITLE
Embed static service details and default selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,52 +120,58 @@
       <div id="servicesPanel" class="mt-10 lg:flex lg:gap-8">
         <ul id="serviceList" class="space-y-4 lg:w-1/3">
           <li>
-            <button type="button" class="service-card w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="porsche-servicing" data-url="https://www.rd9.co.uk/porsche-servicing">
+            <button type="button" class="service-card relative w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="porsche-servicing">
               <img src="icons/porsche-servicing.svg" alt="" class="h-10 w-10 mb-4" />
               <h3 class="font-semibold text-lg">Porsche Servicing</h3>
               <p class="mt-2 text-sm text-neutral-300">We offer a wide range of servicing and repairs… genuine Porsche parts… or the very best of the aftermarket.</p>
+              <svg class="chevron absolute top-6 right-6 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </button>
-            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"></div>
+            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"><p>We offer a wide range of servicing and repairs using genuine Porsche parts or the very best aftermarket alternatives. All work is carried out to factory standards by our experienced technicians.</p></div>
           </li>
           <li>
-            <button type="button" class="service-card w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="performance" data-url="https://www.rd9.co.uk/performance">
+            <button type="button" class="service-card relative w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="performance">
               <img src="icons/performance.svg" alt="" class="h-10 w-10 mb-4" />
               <h3 class="font-semibold text-lg">Performance</h3>
               <p class="mt-2 text-sm text-neutral-300">Unlock the full potential of your vehicle… tuning options… package deal with one of our performance maps.</p>
+              <svg class="chevron absolute top-6 right-6 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </button>
-            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"></div>
+            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"><p>Unlock the full potential of your vehicle with tailored tuning options. From hardware upgrades to custom ECU maps, we can build a package to meet your goals.</p></div>
           </li>
           <li>
-            <button type="button" class="service-card w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="prestige" data-url="https://www.rd9.co.uk/prestige">
+            <button type="button" class="service-card relative w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="prestige">
               <img src="icons/prestige.svg" alt="" class="h-10 w-10 mb-4" />
               <h3 class="font-semibold text-lg">Prestige</h3>
               <p class="mt-2 text-sm text-neutral-300">We understand that your luxury vehicle demands nothing but the best…</p>
+              <svg class="chevron absolute top-6 right-6 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </button>
-            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"></div>
+            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"><p>Our technicians know that luxury vehicles demand meticulous care. From routine maintenance to complex diagnostics, we handle high-end marques with the respect they deserve.</p></div>
           </li>
           <li>
-            <button type="button" class="service-card w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="electric-hybrid" data-url="https://www.rd9.co.uk/electric-hybrid">
+            <button type="button" class="service-card relative w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="electric-hybrid">
               <img src="icons/electric-hybrid.svg" alt="" class="h-10 w-10 mb-4" />
-              <h3 class="font-semibold text-lg">Electric & Hybrid</h3>
+              <h3 class="font-semibold text-lg">Electric &amp; Hybrid</h3>
               <p class="mt-2 text-sm text-neutral-300">We offer fully qualified High Voltage technicians…</p>
+              <svg class="chevron absolute top-6 right-6 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </button>
-            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"></div>
+            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"><p>We provide fully qualified high-voltage technicians for EV and hybrid maintenance. Whether it is a routine battery health check or component replacement, you're in safe hands.</p></div>
           </li>
           <li>
-            <button type="button" class="service-card w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="wheel-alignment" data-url="https://www.rd9.co.uk/wheel-alignment">
+            <button type="button" class="service-card relative w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="wheel-alignment">
               <img src="icons/wheel-alignment.svg" alt="" class="h-10 w-10 mb-4" />
               <h3 class="font-semibold text-lg">Wheel Alignment</h3>
               <p class="mt-2 text-sm text-neutral-300">Suspension alignments are a critical aspect of vehicle maintenance…</p>
+              <svg class="chevron absolute top-6 right-6 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </button>
-            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"></div>
+            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"><p>Suspension alignments are a critical aspect of vehicle maintenance. Our precision equipment ensures your car tracks true and performs at its best.</p></div>
           </li>
           <li>
-            <button type="button" class="service-card w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="pre-purchase-inspections" data-url="https://www.rd9.co.uk/pre-purchase-inspections">
+            <button type="button" class="service-card relative w-full text-left rounded-lg border border-white/10 p-6 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="pre-purchase-inspections">
               <img src="icons/pre-purchase.svg" alt="" class="h-10 w-10 mb-4" />
               <h3 class="font-semibold text-lg">Pre-Purchase Inspections</h3>
               <p class="mt-2 text-sm text-neutral-300">A pre-purchase Inspection gives you a more in-depth understanding of what you’re buying…</p>
+              <svg class="chevron absolute top-6 right-6 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </button>
-            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"></div>
+            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"><p>A pre-purchase inspection gives you a deeper understanding of a vehicle before you commit. We'll highlight issues and maintenance items so you can buy with confidence.</p></div>
           </li>
         </ul>
         <div id="serviceDetail" class="mt-6 hidden lg:block lg:w-2/3">
@@ -901,40 +907,40 @@
 
         function closeDetails() {
           list.querySelectorAll('.service-details').forEach(d => d.classList.add('hidden'));
-        }
-
-        async function loadService(btn) {
-          const url = btn.dataset.url;
-          try {
-            const html = await fetch(url).then(r => r.text());
-            const doc = new DOMParser().parseFromString(html, 'text/html');
-            const main = doc.querySelector('main') || doc.body;
-            return main.innerHTML;
-          } catch (e) {
-            return '<p class="text-sm text-red-400">Failed to load service details.</p>';
-          }
+          list.querySelectorAll('.chevron').forEach(i => i.classList.remove('rotate-180'));
         }
 
         list.querySelectorAll('.service-card').forEach(btn => {
-          btn.addEventListener('click', async () => {
+          btn.addEventListener('click', () => {
             const parentLi = btn.parentElement;
             const details = parentLi.querySelector('.service-details');
-            clearActive();
-            btn.classList.add('ring-2', 'ring-white/40');
+            const icon = btn.querySelector('.chevron');
             if (isDesktop()) {
+              clearActive();
+              btn.classList.add('ring-2', 'ring-white/40');
               detailPanel.classList.remove('hidden');
-              detailContent.innerHTML = '<p class="text-sm text-neutral-300">Loading…</p>';
-              detailContent.innerHTML = await loadService(btn);
+              detailContent.innerHTML = details.innerHTML;
             } else {
-              closeDetails();
-              detailContent.innerHTML = '';
-              details.innerHTML = '<p class="text-sm text-neutral-300">Loading…</p>';
-              details.classList.remove('hidden');
-              details.innerHTML = await loadService(btn);
-              parentLi.scrollIntoView({ behavior: 'smooth', block: 'start' });
+              if (details.classList.contains('hidden')) {
+                closeDetails();
+                clearActive();
+                details.classList.remove('hidden');
+                btn.classList.add('ring-2', 'ring-white/40');
+                icon && icon.classList.add('rotate-180');
+                parentLi.scrollIntoView({ behavior: 'smooth', block: 'start' });
+              } else {
+                details.classList.add('hidden');
+                btn.classList.remove('ring-2', 'ring-white/40');
+                icon && icon.classList.remove('rotate-180');
+              }
             }
           });
         });
+
+        const firstBtn = list.querySelector('.service-card');
+        if (firstBtn && isDesktop()) {
+          firstBtn.click();
+        }
       })();
     </script>
 


### PR DESCRIPTION
## Summary
- Replace dynamic service fetches with static descriptions and add mobile-friendly toggle icons.
- Show service content without loading remote pages and highlight first service by default on desktops.

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b98f26fcb88324acc32d97b9e813df