### PR TITLE
feat: make about section responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -613,11 +613,13 @@
   <section id="about" class="border-t border-white/10 bg-neutral-900/50">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
       <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-white">About</h2>
-      <div class="mt-6 max-w-3xl space-y-4 text-neutral-300">
-        <p><strong>The Gold Standard</strong><br>RD9 was founded in 2020 by Ryan Day. Ryan started his career at Porsche back in 2007 where he went through his apprenticeship all the way to achieving the gold certification in 2018. Over the last year he’s been venturing into other prestigious manufactures from lotus to Lamborghini. Now his goal is to take what he thinks works from the main dealers and add the personal touch that’s much needed.</p>
-      </div>
-      <div class="mt-10">
-        <img src="66e04639cc2cc749eb6111c2_62eaa221af55929f9612ef9a_Untitled.jpeg" alt="RD9 workshop" class="rounded-lg shadow-lg mx-auto" />
+      <div class="mt-6 grid gap-10 lg:grid-cols-2 lg:items-center">
+        <div class="max-w-3xl space-y-4 text-neutral-300">
+          <p><strong>The Gold Standard</strong><br>RD9 was founded in 2020 by Ryan Day. Ryan started his career at Porsche back in 2007 where he went through his apprenticeship all the way to achieving the gold certification in 2018. Over the last year he’s been venturing into other prestigious manufactures from lotus to Lamborghini. Now his goal is to take what he thinks works from the main dealers and add the personal touch that’s much needed.</p>
+        </div>
+        <div>
+          <img src="66e04639cc2cc749eb6111c2_62eaa221af55929f9612ef9a_Untitled.jpeg" alt="RD9 workshop" class="rounded-lg shadow-lg mx-auto lg:mx-0" />
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- display About section content in a two-column grid on large screens
- keep content stacked in a single column on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b98f7e3854832495337845c84c4735