### PR TITLE
fix: stabilize mobile nav bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,9 @@
     }
   </style>
 </head>
-<body id="home" class="bg-neutral-950 text-neutral-100 antialiased min-vh-100">
+<body id="home" class="bg-neutral-950 text-neutral-100 antialiased min-vh-100 pt-16" style="padding-top: calc(env(safe-area-inset-top) + 4rem);">
   <!-- Header / Nav -->
-  <header class="sticky top-0 z-40 backdrop-blur bg-neutral-950/70 border-b border-white/10">
+  <header class="fixed top-0 left-0 w-full z-40 backdrop-blur bg-neutral-950/70 border-b border-white/10" style="padding-top: env(safe-area-inset-top);">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
       <a href="#home" class="flex items-center">
         <img src="RD9-simple-white.svg" alt="RD9 Automotive logo" class="h-8 w-auto">


### PR DESCRIPTION
## Summary
- make header fixed with safe-area padding to prevent jitter on iOS Safari
- offset body content to account for fixed header height and notch

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9983f41988324a617464e2ef67218