### PR TITLE
Remove service card subheadings

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,6 @@
               <img src="icons/porsche-servicing.svg" alt="" class="h-10 w-10 flex-shrink-0" />
               <div class="flex-1">
                 <h3 class="font-semibold text-lg">Porsche Servicing</h3>
-                <p class="mt-1 text-sm text-neutral-300">We offer a wide range of servicing and repairs to meet your requirements. Whether that be servicing using genuine Porsche parts (required when your car is under manufacturer warranty) or the very best of the aftermarket. </p>
               </div>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </button>
@@ -135,7 +134,6 @@
               <img src="icons/performance.svg" alt="" class="h-10 w-10 flex-shrink-0" />
               <div class="flex-1">
                 <h3 class="font-semibold text-lg">Performance</h3>
-                <p class="mt-1 text-sm text-neutral-300">Unlock the full potential of your vehicle… tuning options… package deal with one of our performance maps.</p>
               </div>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </button>
@@ -158,7 +156,6 @@
               <img src="icons/prestige.svg" alt="" class="h-10 w-10 flex-shrink-0" />
               <div class="flex-1">
                 <h3 class="font-semibold text-lg">Prestige</h3>
-                <p class="mt-1 text-sm text-neutral-300">We understand that your luxury vehicle demands nothing but the best…</p>
               </div>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </button>
@@ -174,7 +171,6 @@
               <img src="icons/electric-hybrid.svg" alt="" class="h-10 w-10 flex-shrink-0" />
               <div class="flex-1">
                 <h3 class="font-semibold text-lg">Electric &amp; Hybrid</h3>
-                <p class="mt-1 text-sm text-neutral-300">We offer fully qualified High Voltage technicians…</p>
               </div>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </button>
@@ -188,7 +184,6 @@
               <img src="icons/wheel-alignment.svg" alt="" class="h-10 w-10 flex-shrink-0" />
               <div class="flex-1">
                 <h3 class="font-semibold text-lg">Wheel Alignment</h3>
-                <p class="mt-1 text-sm text-neutral-300">Suspension alignments are a critical aspect of vehicle maintenance…</p>
               </div>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </button>
@@ -207,7 +202,6 @@
               <img src="icons/pre-purchase.svg" alt="" class="h-10 w-10 flex-shrink-0" />
               <div class="flex-1">
                 <h3 class="font-semibold text-lg">Pre-Purchase Inspections</h3>
-                <p class="mt-1 text-sm text-neutral-300">A pre-purchase Inspection gives you a more in-depth understanding of what you’re buying…</p>
               </div>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </button>


### PR DESCRIPTION
## Summary
- Remove descriptive subheading text from each service card, leaving only the icon and service name

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b99b5f780c83249796cd8e29a04f83