### PR TITLE
Move service CTAs into detail panes

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,20 +122,18 @@
           <li>
             <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-start gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="porsche-servicing">
               <img src="icons/porsche-servicing.svg" alt="" class="h-10 w-10 flex-shrink-0" />
-              <div class="flex-1 flex flex-col">
+              <div class="flex-1">
                 <h3 class="font-semibold text-lg">Porsche Servicing</h3>
-                <a href="#prices" onclick="event.stopPropagation()" class="mt-auto self-center inline-flex items-center rounded-md bg-brand text-neutral-900 px-3 py-2 text-sm font-medium hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/50">View Prices</a>
               </div>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </div>
-            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"><p>We offer a wide range of servicing and repairs to meet your requirements. Whether that be servicing using genuine Porsche parts (required when your car is under manufacturer warranty) or the very best of the aftermarket.</p></div>
+            <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"><p>We offer a wide range of servicing and repairs to meet your requirements. Whether that be servicing using genuine Porsche parts (required when your car is under manufacturer warranty) or the very best of the aftermarket.</p><a href="#prices" class="mt-4 inline-flex items-center rounded-md bg-brand text-neutral-900 px-3 py-2 text-sm font-medium hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/50">View Prices</a></div>
           </li>
           <li>
             <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-start gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="performance">
               <img src="icons/performance.svg" alt="" class="h-10 w-10 flex-shrink-0" />
-              <div class="flex-1 flex flex-col">
+              <div class="flex-1">
                 <h3 class="font-semibold text-lg">Performance</h3>
-                <a href="#contact" onclick="event.stopPropagation()" class="mt-auto self-center inline-flex items-center rounded-md bg-brand text-neutral-900 px-3 py-2 text-sm font-medium hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/50">Contact Us</a>
               </div>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </div>
@@ -151,14 +149,14 @@
               <p class="mt-2">We can offer multiple options whether you are just looking to lower your car or a full suspension overhaul using fully adjustable suspension components. These setups can include fully adjustable coilovers, uprated anti roll bars and adjustable suspension arms/bushes. Depending on your choices we can match the modifications with a custom wheel alignment setup to suit your intended use.</p>
               <h4 class="font-semibold mt-4">Brakes</h4>
               <p class="mt-2">We can offer from big brake setups or replacement of original pads and discs with uprated parts ideal for fast road or track use.</p>
+              <a href="#contact" class="mt-4 inline-flex items-center rounded-md bg-brand text-neutral-900 px-3 py-2 text-sm font-medium hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/50">Contact Us</a>
             </div>
           </li>
           <li>
             <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-start gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="prestige">
               <img src="icons/prestige.svg" alt="" class="h-10 w-10 flex-shrink-0" />
-              <div class="flex-1 flex flex-col">
+              <div class="flex-1">
                 <h3 class="font-semibold text-lg">Prestige</h3>
-                <a href="#contact" onclick="event.stopPropagation()" class="mt-auto self-center inline-flex items-center rounded-md bg-brand text-neutral-900 px-3 py-2 text-sm font-medium hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/50">Contact Us</a>
               </div>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </div>
@@ -167,28 +165,28 @@
               <p class="mt-4">From SUV’s to two seat convertible sports cars we can offer servicing and repairs along with modifications and multitude of retro fits.</p>
               <p class="mt-4">We look after a large variation of prestige cars from under a year old to even dating back to the 1930’s. We spend time to build up a good relationship to get a better understanding of your expectations, manage repairs and budgets.</p>
               <p class="mt-4">If it’s a seasonal car we aim to make sure your car is ready and reliable for those important spring and summer months with larger repairs planned for winter months where the car is not in use.</p>
+              <a href="#contact" class="mt-4 inline-flex items-center rounded-md bg-brand text-neutral-900 px-3 py-2 text-sm font-medium hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/50">Contact Us</a>
             </div>
           </li>
           <li>
             <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-start gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="electric-hybrid">
               <img src="icons/electric-hybrid.svg" alt="" class="h-10 w-10 flex-shrink-0" />
-              <div class="flex-1 flex flex-col">
+              <div class="flex-1">
                 <h3 class="font-semibold text-lg">Electric &amp; Hybrid</h3>
-                <a href="#contact" onclick="event.stopPropagation()" class="mt-auto self-center inline-flex items-center rounded-md bg-brand text-neutral-900 px-3 py-2 text-sm font-medium hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/50">Contact Us</a>
               </div>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </div>
             <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden">
               <p>We offer fully qualified High Voltage technicians to take care of your electric or hybrid vehicle. From routine maintenance to large repairs of the High Voltage systems we have you covered.</p>
               <p class="mt-4">Due to variation between makes and models for all non Porsche enquiries please contact us to discuss required repairs or servicing.</p>
+              <a href="#contact" class="mt-4 inline-flex items-center rounded-md bg-brand text-neutral-900 px-3 py-2 text-sm font-medium hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/50">Contact Us</a>
             </div>
           </li>
           <li>
             <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-start gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="wheel-alignment">
               <img src="icons/wheel-alignment.svg" alt="" class="h-10 w-10 flex-shrink-0" />
-              <div class="flex-1 flex flex-col">
+              <div class="flex-1">
                 <h3 class="font-semibold text-lg">Wheel Alignment</h3>
-                <a href="#contact" onclick="event.stopPropagation()" class="mt-auto self-center inline-flex items-center rounded-md bg-brand text-neutral-900 px-3 py-2 text-sm font-medium hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/50">Contact Us</a>
               </div>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </div>
@@ -200,20 +198,21 @@
               <p class="mt-2">Regular suspension alignments are essential for prolonging the life of your tires, ensuring a smooth ride, and maintaining fuel efficiency. Misaligned suspensions can lead to uneven tire wear, poor handling, and even increased fuel consumption. It's advisable to have your vehicle's alignment checked periodically, especially after encountering significant potholes, curbs, or other impacts.</p>
               <p class="mt-2">In essence, suspension alignment is not just about keeping the wheels straight; it's about ensuring your vehicle operates at its peak performance, providing you with a safer and more enjoyable driving experience.</p>
               <p class="mt-2">Custom alignments can be tailored to fit your specific driving needs and preferences. Whether you're looking to enhance your vehicle's handling for track days, improve comfort for daily commuting, or achieve the perfect stance for car shows, the right suspension setup can make all the difference.</p>
+              <a href="#contact" class="mt-4 inline-flex items-center rounded-md bg-brand text-neutral-900 px-3 py-2 text-sm font-medium hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/50">Contact Us</a>
             </div>
           </li>
           <li>
             <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-start gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="pre-purchase-inspections">
               <img src="icons/pre-purchase.svg" alt="" class="h-10 w-10 flex-shrink-0" />
-              <div class="flex-1 flex flex-col">
+              <div class="flex-1">
                 <h3 class="font-semibold text-lg">Pre-Purchase Inspections</h3>
-                <a href="#contact" onclick="event.stopPropagation()" class="mt-auto self-center inline-flex items-center rounded-md bg-brand text-neutral-900 px-3 py-2 text-sm font-medium hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/50">Contact Us</a>
               </div>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </div>
             <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden">
               <p>A pre-purchase inspection is a crucial step in the process of buying a used car. This comprehensive assessment, conducted by one of our experienced technicians, aims to evaluate the overall condition of the vehicle before finalising the purchase. During the inspection, various aspects of the car are examined, including the engine, transmission, brakes, suspension, tires, and electrical systems. Additionally, the technician will check for any signs of previous accidents, rust, or hidden damage that may not be immediately apparent. The goal of this inspection is to provide you with a clear understanding of the vehicle's current state, uncover any potential issues that could lead to costly repairs in the future, and ultimately ensure that you are making a well-informed decision. Investing in a pre-purchase inspection can save you from unexpected headaches and financial burdens, making it a wise move for any prospective owner.</p>
               <p class="mt-4">After the PPI is carried out you will be sent a full report consisting of a digital vehicle health check consisting of photos and a walk around video of the vehicle. Also you will receive a full diagnostic report.</p>
+              <a href="#contact" class="mt-4 inline-flex items-center rounded-md bg-brand text-neutral-900 px-3 py-2 text-sm font-medium hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/50">Contact Us</a>
             </div>
           </li>
         </ul>


### PR DESCRIPTION
## Summary
- Relocated service call-to-action links into their respective detail panels and removed them from list cards.

## Testing
- `npx -y html-validate index.html` *(fails: 36 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b99d5688d88324adaa741c552a98ff