### PR TITLE
Center service icons and headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,21 +120,17 @@
       <div id="servicesPanel" class="mt-10 lg:flex lg:items-stretch lg:gap-8">
         <ul id="serviceList" class="space-y-4 lg:space-y-8 lg:w-1/3">
           <li>
-            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-start gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="porsche-servicing">
+            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center justify-center gap-4 text-center rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="porsche-servicing">
               <img src="icons/porsche-servicing.svg" alt="" class="h-10 w-10 flex-shrink-0" />
-              <div class="flex-1">
-                <h3 class="font-semibold text-lg">Porsche Servicing</h3>
-              </div>
+              <h3 class="font-semibold text-lg">Porsche Servicing</h3>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </div>
             <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"><p>We offer a wide range of servicing and repairs to meet your requirements. Whether that be servicing using genuine Porsche parts (required when your car is under manufacturer warranty) or the very best of the aftermarket.</p><a href="#prices" class="mt-4 inline-flex items-center rounded-md bg-brand text-neutral-900 px-3 py-2 text-sm font-medium hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/50">View Prices</a></div>
           </li>
           <li>
-            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-start gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="performance">
+            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center justify-center gap-4 text-center rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="performance">
               <img src="icons/performance.svg" alt="" class="h-10 w-10 flex-shrink-0" />
-              <div class="flex-1">
-                <h3 class="font-semibold text-lg">Performance</h3>
-              </div>
+              <h3 class="font-semibold text-lg">Performance</h3>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </div>
             <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden">
@@ -153,11 +149,9 @@
             </div>
           </li>
           <li>
-            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-start gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="prestige">
+            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center justify-center gap-4 text-center rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="prestige">
               <img src="icons/prestige.svg" alt="" class="h-10 w-10 flex-shrink-0" />
-              <div class="flex-1">
-                <h3 class="font-semibold text-lg">Prestige</h3>
-              </div>
+              <h3 class="font-semibold text-lg">Prestige</h3>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </div>
             <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden">
@@ -169,11 +163,9 @@
             </div>
           </li>
           <li>
-            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-start gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="electric-hybrid">
+            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center justify-center gap-4 text-center rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="electric-hybrid">
               <img src="icons/electric-hybrid.svg" alt="" class="h-10 w-10 flex-shrink-0" />
-              <div class="flex-1">
-                <h3 class="font-semibold text-lg">Electric &amp; Hybrid</h3>
-              </div>
+              <h3 class="font-semibold text-lg">Electric &amp; Hybrid</h3>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </div>
             <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden">
@@ -183,11 +175,9 @@
             </div>
           </li>
           <li>
-            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-start gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="wheel-alignment">
+            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center justify-center gap-4 text-center rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="wheel-alignment">
               <img src="icons/wheel-alignment.svg" alt="" class="h-10 w-10 flex-shrink-0" />
-              <div class="flex-1">
-                <h3 class="font-semibold text-lg">Wheel Alignment</h3>
-              </div>
+              <h3 class="font-semibold text-lg">Wheel Alignment</h3>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </div>
             <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden">
@@ -202,11 +192,9 @@
             </div>
           </li>
           <li>
-            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-start gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="pre-purchase-inspections">
+            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center justify-center gap-4 text-center rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="pre-purchase-inspections">
               <img src="icons/pre-purchase.svg" alt="" class="h-10 w-10 flex-shrink-0" />
-              <div class="flex-1">
-                <h3 class="font-semibold text-lg">Pre-Purchase Inspections</h3>
-              </div>
+              <h3 class="font-semibold text-lg">Pre-Purchase Inspections</h3>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
             </div>
             <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden">


### PR DESCRIPTION
## Summary
- Center service list icons and headings by switching service cards to a centered flex layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b99e61fe948324b93f1725d663cf9c