### PR TITLE
Fix service card alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
       <div id="servicesPanel" class="mt-10 lg:flex lg:items-stretch lg:gap-8">
         <ul id="serviceList" class="space-y-4 lg:space-y-8 lg:w-1/3">
           <li>
-            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center justify-center gap-4 text-center rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="porsche-servicing">
+            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="porsche-servicing">
               <img src="icons/porsche-servicing.svg" alt="" class="h-10 w-10 flex-shrink-0" />
               <h3 class="font-semibold text-lg">Porsche Servicing</h3>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
@@ -128,7 +128,7 @@
             <div class="service-details mt-4 p-4 rounded-lg border border-white/10 bg-neutral-900 hidden lg:hidden"><p>We offer a wide range of servicing and repairs to meet your requirements. Whether that be servicing using genuine Porsche parts (required when your car is under manufacturer warranty) or the very best of the aftermarket.</p><a href="#prices" class="mt-4 inline-flex items-center rounded-md bg-brand text-neutral-900 px-3 py-2 text-sm font-medium hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/50">View Prices</a></div>
           </li>
           <li>
-            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center justify-center gap-4 text-center rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="performance">
+            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="performance">
               <img src="icons/performance.svg" alt="" class="h-10 w-10 flex-shrink-0" />
               <h3 class="font-semibold text-lg">Performance</h3>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
@@ -149,7 +149,7 @@
             </div>
           </li>
           <li>
-            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center justify-center gap-4 text-center rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="prestige">
+            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="prestige">
               <img src="icons/prestige.svg" alt="" class="h-10 w-10 flex-shrink-0" />
               <h3 class="font-semibold text-lg">Prestige</h3>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
@@ -163,7 +163,7 @@
             </div>
           </li>
           <li>
-            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center justify-center gap-4 text-center rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="electric-hybrid">
+            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="electric-hybrid">
               <img src="icons/electric-hybrid.svg" alt="" class="h-10 w-10 flex-shrink-0" />
               <h3 class="font-semibold text-lg">Electric &amp; Hybrid</h3>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
@@ -175,7 +175,7 @@
             </div>
           </li>
           <li>
-            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center justify-center gap-4 text-center rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="wheel-alignment">
+            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="wheel-alignment">
               <img src="icons/wheel-alignment.svg" alt="" class="h-10 w-10 flex-shrink-0" />
               <h3 class="font-semibold text-lg">Wheel Alignment</h3>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
@@ -192,7 +192,7 @@
             </div>
           </li>
           <li>
-            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center justify-center gap-4 text-center rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="pre-purchase-inspections">
+            <div role="button" tabindex="0" class="service-card cursor-pointer relative w-full flex items-center gap-4 text-left rounded-lg border border-white/10 p-6 pr-12 bg-neutral-900 opacity-0 transition transform hover:-translate-y-1 hover:bg-neutral-800 hover:border-white/20" data-service="pre-purchase-inspections">
               <img src="icons/pre-purchase.svg" alt="" class="h-10 w-10 flex-shrink-0" />
               <h3 class="font-semibold text-lg">Pre-Purchase Inspections</h3>
               <svg class="chevron absolute right-6 top-1/2 -translate-y-1/2 h-5 w-5 text-neutral-400 transition-transform lg:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>


### PR DESCRIPTION
## Summary
- Left-align service cards and keep vertical centering by removing flex justification and using `text-left`

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b99fa5caf483249ea678f3deba65dc