### PR TITLE
fix: stabilize navbar on iOS Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,8 +21,8 @@
     .animate-rise { animation: rise .8s ease-out both }
     .price-section table { width:100%; table-layout:fixed; }
     .price-section th, .price-section td { width:33.333%; }
-    .vh-100 { height:100vh; height:100lvh; }
-    .min-vh-100 { min-height:100vh; min-height:100lvh; }
+    .vh-100 { height:100vh; height:100dvh; }
+    .min-vh-100 { min-height:100vh; min-height:100dvh; }
     :root { --brand: rgb(255,215,0); }
     .text-brand { color: var(--brand); }
     .bg-brand { background-color: var(--brand); }


### PR DESCRIPTION
## Summary
- use dynamic viewport units for full-height layout to prevent navbar jump on iOS Safari

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a0ef616483249225d175cbef04cb