### PR TITLE
Refine About section layout for desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -649,8 +649,8 @@
   <section id="about" class="border-t border-white/10 bg-neutral-900/50">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
       <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-white">About</h2>
-      <div class="mt-6 grid gap-10 lg:grid-cols-2 lg:items-center">
-        <div class="max-w-3xl space-y-4 text-neutral-300">
+      <div class="mt-6 grid gap-10 lg:grid-cols-3 lg:items-start">
+        <div class="space-y-4 text-neutral-300 lg:col-span-2">
           <p><strong>The Gold Standard</strong><br>RD9 was founded in 2020 by Ryan Day. Ryan started his career at Porsche back in 2007 where he went through his apprenticeship all the way to achieving the gold certification in 2018. Over the last year he’s been venturing into other prestigious manufactures from lotus to Lamborghini. Now his goal is to take what he thinks works from the main dealers and add the personal touch that’s much needed.</p>
         </div>
         <div>


### PR DESCRIPTION
## Summary
- Make About section use a two-thirds text and one-third image layout on large screens
- Align About section text and image to the top on desktop

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a38a4d3c83249370e1ebacf67258