### PR TITLE
Mask hero gold glint to text only

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,20 +35,23 @@
       text-shadow: 0 0 4px rgba(255,215,0,0.3);
     }
     .glint::after {
-      content: "";
+      content: attr(data-text);
       position: absolute;
       top: 0;
-      left: -50%;
-      width: 50%;
+      left: -100%;
+      width: 100%;
       height: 100%;
       background: linear-gradient(120deg, transparent, rgba(255,255,255,0.6), transparent);
+      background-clip: text;
+      -webkit-background-clip: text;
+      color: transparent;
       transform: skewX(-20deg);
       pointer-events: none;
       animation: glint 4s ease-in-out infinite;
     }
     @keyframes glint {
-      from { left: -50%; }
-      to { left: 150%; }
+      from { left: -100%; }
+      to { left: 100%; }
     }
     #home, section { scroll-margin-top: calc(env(safe-area-inset-top) + 4rem); }
     /* Style car model datalist dropdown on desktop */
@@ -116,7 +119,7 @@
     <div class="absolute inset-0 opacity-20 bg-[url('tyre-tread.svg')] bg-repeat pointer-events-none"></div>
     <div class="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-24 sm:py-28 lg:py-36">
       <div class="max-w-3xl animate-rise">
-        <h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold tracking-tight text-white">The <span class="text-brand glint">Gold</span> Standard</h1>
+        <h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold tracking-tight text-white">The <span class="text-brand glint" data-text="Gold">Gold</span> Standard</h1>
         <p class="mt-6 text-lg text-neutral-300">
           Welcome to RD9 Automotive, Porsche and Prestige vehicle specialists. We feel that, for too long, the motor trade has fallen short, and we are here to change that.
           From a prized possession to your everyday vehicle, we are here to maintain, repair and modify your vehicles to the highest of standards.


### PR DESCRIPTION
## Summary
- Limit the hero heading's gold glint to the word "Gold" by masking the animation to text.
- Add data attribute for the word and update animation to slide over the clipped text.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a52485f48324b1d801586c7ad458