### PR TITLE
Add missing Porsche models with estimated service pricing

### DIFF
--- a/price-list.csv
+++ b/price-list.csv
@@ -93,7 +93,6 @@ Macan Turbo / GTS (2014–2023),Major Service,40k miles / 4 years,£485
 Macan Turbo / GTS (2014–2023),Spark Plugs,40k miles / 6 years,£210
 Macan Turbo / GTS (2014–2023),PDK Oil,40k miles / 6 years,£290
 Macan Turbo / GTS (2014–2023),Brake Fluid Change,Every 2 years,£95
-Panamera,No items found,,
 Cayenne V6 (958 E2) (2010–2017),Oil Service,Timeline variable,£225
 Cayenne V6 (958 E2) (2010–2017),Minor Service,20k miles / 2 years,£265
 Cayenne V6 (958 E2) (2010–2017),Major Service,40k miles / 4 years,£325
@@ -109,3 +108,24 @@ Cayenne / S / GTS (958 E2) (2010–2017),Minor Service,20k miles / 2 years,£265
 Cayenne / S / GTS (958 E2) (2010–2017),Major Service,40k miles / 4 years,£325
 Cayenne / S / GTS (958 E2) (2010–2017),Brake Fluid Change,Every 2 years,£75
 Cayenne / S / GTS (958 E2) (2010–2017),Air Filter / Aux Belt,Various,POA
+Panamera (2016–2022),Minor Service,20k miles / 2 years,£400
+Panamera (2016–2022),Major Service,40k miles / 4 years,£485
+Panamera (2016–2022),Spark Plugs,40k miles / 6 years,£210
+Panamera (2016–2022),PDK Oil,40k miles / 6 years,£290
+Panamera (2016–2022),Brake Fluid Change,Every 2 years,£95
+Taycan (2020–2023),Minor Service,20k miles / 2 years,£400
+Taycan (2020–2023),Major Service,40k miles / 4 years,£485
+Taycan (2020–2023),Brake Fluid Change,Every 2 years,£95
+Cayenne (E3) (2018–2023),Oil Service,Timeline variable,£235
+Cayenne (E3) (2018–2023),Minor Service,20k miles / 2 years,£275
+Cayenne (E3) (2018–2023),Major Service,40k miles / 4 years,£335
+Cayenne (E3) (2018–2023),Brake Fluid Change,Every 2 years,£75
+Cayenne (E3) (2018–2023),Air Filter / Aux Belt,Various,POA
+911 (993) (1994–1998),Minor Service,12k miles / 2 years,£335
+911 (993) (1994–1998),Major Service,24k miles / 4 years,£430
+911 (993) (1994–1998),Spark Plugs,24k miles / 4 years,£210
+911 (993) (1994–1998),Brake Fluid Change,Every 2 years,£95
+911 (964) (1989–1994),Minor Service,12k miles / 2 years,£340
+911 (964) (1989–1994),Major Service,24k miles / 4 years,£435
+911 (964) (1989–1994),Spark Plugs,24k miles / 4 years,£215
+911 (964) (1989–1994),Brake Fluid Change,Every 2 years,£95


### PR DESCRIPTION
## Summary
- estimate service pricing for Panamera (2016–2022) and Taycan (2020–2023)
- include latest Cayenne (E3) model with service costs
- add legacy 911 models (993 and 964) with suggested maintenance prices

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a767cf148324b8a7824c76017b8b