### PR TITLE
Refine gold glint to outline highlight

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,20 +39,31 @@
       content: attr(data-text);
       position: absolute;
       top: 0;
-      left: -100%;
+      left: 0;
       width: 100%;
       height: 100%;
-      background: linear-gradient(120deg, transparent, rgba(255,255,255,0.6), transparent);
-      background-clip: text;
-      -webkit-background-clip: text;
       color: transparent;
-      transform: skewX(-20deg);
+      -webkit-text-stroke: 2px rgba(255,255,255,0.8);
+      mask-image: linear-gradient(120deg, transparent 40%, rgba(255,255,255,0.8) 50%, transparent 60%);
+      -webkit-mask-image: linear-gradient(120deg, transparent 40%, rgba(255,255,255,0.8) 50%, transparent 60%);
+      mask-size: 200% 100%;
+      -webkit-mask-size: 200% 100%;
+      mask-repeat: no-repeat;
+      -webkit-mask-repeat: no-repeat;
+      mask-position: -100% 0;
+      -webkit-mask-position: -100% 0;
       pointer-events: none;
       animation: glint 4s ease-in-out infinite;
     }
     @keyframes glint {
-      from { left: -100%; }
-      to { left: 100%; }
+      from {
+        mask-position: -100% 0;
+        -webkit-mask-position: -100% 0;
+      }
+      to {
+        mask-position: 100% 0;
+        -webkit-mask-position: 100% 0;
+      }
     }
     #home, section { scroll-margin-top: calc(env(safe-area-inset-top) + 4rem); }
     /* Style car model datalist dropdown on desktop */


### PR DESCRIPTION
## Summary
- Rework gold glint animation to highlight an outline rather than a skewed overlay
- Animate mask position across a stroked duplicate text for beveled-edge sheen

## Testing
- ⚠️ `npx prettier --check index.html` (code style issues found)
- ⚠️ `npm test` (missing package.json / no test script)

------
https://chatgpt.com/codex/tasks/task_e_68b9a80b5ffc832481fe929e92335137