### PR TITLE
Fix gold glint baseline alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,9 +31,10 @@
     .active-link { text-decoration: underline; text-decoration-color: rgba(var(--brand-rgb), var(--active-opacity, 1)); text-underline-offset: 4px; }
     .glint {
       position: relative;
-      display: inline-block;
+      display: inline;
       overflow: hidden;
       text-shadow: 0 0 4px rgba(255,215,0,0.3);
+      line-height: inherit;
     }
     .glint::after {
       content: attr(data-text);


### PR DESCRIPTION
## Summary
- Ensure "Gold" glint text stays inline with surrounding heading text by making the glint span display inline and inherit line-height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9aa58e57083249015cd3a1034a664