### PR TITLE
Adjust nav underline color and hover transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,9 @@
     :root { --brand-rgb: 255,215,0; --brand: rgb(var(--brand-rgb)); }
     .text-brand { color: var(--brand); }
     .bg-brand { background-color: var(--brand); }
-    nav a:hover { color: var(--brand); }
-    .active-link { text-decoration: underline; text-decoration-color: rgba(var(--brand-rgb), var(--active-opacity, 1)); text-underline-offset: 4px; }
+    nav a { text-decoration-color: white; transition: color 150ms ease, text-decoration-color 150ms ease; }
+    nav a:hover { color: var(--brand); text-decoration: underline; text-decoration-color: var(--brand); }
+    .active-link { text-decoration: underline; text-decoration-color: white; text-underline-offset: 4px; }
     .glint {
       position: relative;
       display: inline-block;
@@ -1139,21 +1140,13 @@
       });
 
       const observer = new IntersectionObserver(entries => {
-        const viewport = window.innerHeight || 1;
         entries.forEach(entry => {
           const id = entry.target.id;
           const links = linkMap[id] || [];
-          const coverage = entry.intersectionRatio > 0 ? entry.intersectionRect.height / viewport : 0;
-          if (coverage > 0) {
-            links.forEach(l => {
-              l.classList.add('active-link');
-              l.style.setProperty('--active-opacity', coverage.toFixed(2));
-            });
+          if (entry.isIntersecting) {
+            links.forEach(l => l.classList.add('active-link'));
           } else {
-            links.forEach(l => {
-              l.classList.remove('active-link');
-              l.style.removeProperty('--active-opacity');
-            });
+            links.forEach(l => l.classList.remove('active-link'));
           }
         });
       }, { threshold: Array.from({ length: 101 }, (_, i) => i / 100) });


### PR DESCRIPTION
## Summary
- make nav link underlines white by default and brand colored on hover
- add subtle transitions for nav link hover styles and simplify active link observer

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ab15c6148324af2a82bb2c623010