### PR TITLE
Fix glint overlay alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     .active-link { text-decoration: underline; text-decoration-color: rgba(var(--brand-rgb), var(--active-opacity, 1)); text-underline-offset: 4px; }
     .glint {
       position: relative;
-      display: inline;
+      display: inline-block;
       overflow: hidden;
       text-shadow: 0 0 4px rgba(255,215,0,0.3);
       line-height: inherit;
@@ -43,6 +43,9 @@
       left: 0;
       width: 100%;
       height: 100%;
+      font: inherit;
+      letter-spacing: inherit;
+      line-height: inherit;
       color: transparent;
       -webkit-text-stroke: 2px rgba(255,255,255,0.8);
       mask-image: linear-gradient(120deg, transparent 40%, rgba(255,255,255,0.8) 50%, transparent 60%);


### PR DESCRIPTION
## Summary
- ensure glint pseudo-element inherits font sizing for proper overlay alignment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ab8f09c4832491aba8126cf77182