### PR TITLE
Align hero heading words with glint animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
     <div class="absolute inset-0 opacity-20 bg-[url('tyre-tread.svg')] bg-repeat pointer-events-none"></div>
     <div class="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-24 sm:py-28 lg:py-36">
       <div class="max-w-3xl animate-rise">
-        <h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold tracking-tight text-white">The <span class="text-brand glint" data-text="Gold">Gold</span> Standard</h1>
+        <h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold tracking-tight text-white"><span class="inline-block">The&nbsp;</span><span class="text-brand glint inline-block" data-text="Gold">Gold&nbsp;</span><span class="inline-block">Standard</span></h1>
         <p class="mt-6 text-lg text-neutral-300">
           Welcome to RD9 Automotive, Porsche and Prestige vehicle specialists. We feel that, for too long, the motor trade has fallen short, and we are here to change that.
           From a prized possession to your everyday vehicle, we are here to maintain, repair and modify your vehicles to the highest of standards.


### PR DESCRIPTION
## Summary
- Wrap "The" and "Standard" in inline-block spans
- Add non-breaking spaces after "The" and "Gold" for consistent spacing
- Mark all hero heading words as inline-block to align glint animation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ae0d23548324b106386d37e892b1