### PR TITLE
Fix nav link activation under sticky header

### DIFF
--- a/index.html
+++ b/index.html
@@ -1145,6 +1145,9 @@
         }
       });
 
+      const header = document.querySelector('body > header');
+      const offset = header ? header.offsetHeight : 0;
+
       const observer = new IntersectionObserver(entries => {
         entries.forEach(entry => {
           const id = entry.target.id;
@@ -1155,7 +1158,10 @@
             links.forEach(l => l.classList.remove('active-link'));
           }
         });
-      }, { threshold: Array.from({ length: 101 }, (_, i) => i / 100) });
+      }, {
+        threshold: Array.from({ length: 101 }, (_, i) => i / 100),
+        rootMargin: `-${offset}px 0px 0px 0px`
+      });
 
       Object.keys(linkMap).forEach(id => {
         const section = document.getElementById(id);


### PR DESCRIPTION
## Summary
- Adjust IntersectionObserver to offset navigation bar height when determining active sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ae60af248324a5461d33b8e55978