### PR TITLE
Embed full phrase in SVG with masked Gold text

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,9 +147,8 @@
     <div class="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-24 sm:py-28 lg:py-36">
       <div class="max-w-3xl animate-rise">
         <h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold tracking-tight text-white">
-          <span class="inline-block relative top-px">The&nbsp;</span>
-          <span class="sr-only">Gold </span>
-          <svg class="glint-svg inline-block text-brand" viewBox="0 0 120 32" aria-hidden="true" focusable="false">
+          <span class="sr-only">The Gold Standard</span>
+          <svg class="glint-svg inline-block align-baseline" viewBox="0 0 320 32" aria-hidden="true" focusable="false">
             <defs>
               <linearGradient id="glint-gradient" gradientUnits="userSpaceOnUse">
                 <stop offset="0%" stop-color="#fff" stop-opacity="0" />
@@ -158,14 +157,15 @@
               </linearGradient>
               <mask id="glint-mask">
                 <rect x="-60" y="0" width="60" height="32" fill="url(#glint-gradient)">
-                  <animate attributeName="x" from="-60" to="120" dur="4s" repeatCount="indefinite" />
+                  <animate attributeName="x" from="-60" to="320" dur="4s" repeatCount="indefinite" />
                 </rect>
               </mask>
             </defs>
-            <text x="0" y="24" style="font: inherit; fill: currentColor;">Gold</text>
-            <text x="0" y="24" style="font: inherit; fill: #fff;" mask="url(#glint-mask)">Gold</text>
-          </svg>&nbsp;
-          <span class="inline-block relative top-px">Standard</span>
+            <text x="0" y="24" style="font: inherit; fill: #fff;">The</text>
+            <text x="72" y="24" style="font: inherit; fill: var(--brand);">Gold</text>
+            <text x="168" y="24" style="font: inherit; fill: #fff;">Standard</text>
+            <text x="72" y="24" style="font: inherit; fill: #fff;" mask="url(#glint-mask)">Gold</text>
+          </svg>
         </h1>
         <p class="mt-6 text-lg text-neutral-300">
           Welcome to RD9 Automotive, Porsche and Prestige vehicle specialists. We feel that, for too long, the motor trade has fallen short, and we are here to change that.


### PR DESCRIPTION
## Summary
- Render "The Gold Standard" entirely within an SVG
- Apply glint mask and animation only to the word "Gold"
- Align all words consistently with identical font sizing

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b61946488324b721744e000b82e1