### PR TITLE
Fix Gold Standard SVG text sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
       <div class="max-w-3xl animate-rise">
         <h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold tracking-tight text-white">
           <span class="sr-only">The Gold Standard</span>
-          <svg class="glint-svg inline-block align-baseline" viewBox="0 0 320 32" aria-hidden="true" focusable="false">
+          <svg class="glint-svg inline-block align-baseline" viewBox="0 0 320 32" aria-hidden="true" focusable="false" font-size="24" style="font-family: inherit; font-weight: inherit;">
             <defs>
               <linearGradient id="glint-gradient" gradientUnits="userSpaceOnUse">
                 <stop offset="0%" stop-color="#fff" stop-opacity="0" />
@@ -161,10 +161,10 @@
                 </rect>
               </mask>
             </defs>
-            <text x="0" y="24" style="font: inherit; fill: #fff;">The</text>
-            <text x="72" y="24" style="font: inherit; fill: var(--brand);">Gold</text>
-            <text x="168" y="24" style="font: inherit; fill: #fff;">Standard</text>
-            <text x="72" y="24" style="font: inherit; fill: #fff;" mask="url(#glint-mask)">Gold</text>
+            <text x="0" y="24" style="fill: #fff;">The</text>
+            <text x="72" y="24" style="fill: var(--brand);">Gold</text>
+            <text x="168" y="24" style="fill: #fff;">Standard</text>
+            <text x="72" y="24" style="fill: #fff;" mask="url(#glint-mask)">Gold</text>
           </svg>
         </h1>
         <p class="mt-6 text-lg text-neutral-300">


### PR DESCRIPTION
## Summary
- Ensure Gold Standard SVG text uses explicit 24 unit font size to prevent overlapping and oversized letters
- Preserve inherited font family and weight for consistent styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b7f95818832485bd4e0a54a874e5