### PR TITLE
Simplify gold text glint using animated drop-shadow

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,10 +40,18 @@
       text-decoration: underline;
       text-decoration-color: white;
     }
-    .glint-svg {
-      height: 1em;
-      width: auto;
-      overflow: visible;
+    .gold-glint {
+      color: var(--brand);
+      filter: drop-shadow(0 0 1px rgba(0,0,0,0.6)) drop-shadow(-1px 0 0 #fff);
+      animation: glint 4s ease-in-out infinite;
+    }
+    @keyframes glint {
+      0%, 100% {
+        filter: drop-shadow(0 0 1px rgba(0,0,0,0.6)) drop-shadow(-1px 0 0 #fff);
+      }
+      50% {
+        filter: drop-shadow(0 0 1px rgba(0,0,0,0.6)) drop-shadow(1px 0 0 #fff);
+      }
     }
     #home, section { scroll-margin-top: calc(env(safe-area-inset-top) + 4rem); }
     /* Style car model datalist dropdown on desktop */
@@ -159,24 +167,7 @@
       <div class="max-w-3xl animate-rise">
         <h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold tracking-tight text-white">
           <span class="sr-only">The Gold Standard</span>
-          <svg class="glint-svg inline-block align-baseline" viewBox="0 0 320 32" aria-hidden="true" focusable="false" font-size="24" style="font-family: inherit; font-weight: inherit;">
-            <defs>
-              <linearGradient id="glint-gradient" gradientUnits="userSpaceOnUse">
-                <stop offset="0%" stop-color="#fff" stop-opacity="0" />
-                <stop offset="50%" stop-color="#fff" stop-opacity="0.8" />
-                <stop offset="100%" stop-color="#fff" stop-opacity="0" />
-              </linearGradient>
-              <mask id="glint-mask">
-                <rect x="-60" y="0" width="60" height="32" fill="url(#glint-gradient)">
-                  <animate attributeName="x" from="-60" to="320" dur="4s" repeatCount="indefinite" />
-                </rect>
-              </mask>
-            </defs>
-            <text x="0" y="24" style="fill: #fff;">The</text>
-            <text x="72" y="24" style="fill: var(--brand);">Gold</text>
-            <text x="168" y="24" style="fill: #fff;">Standard</text>
-            <text x="72" y="24" style="fill: #fff;" mask="url(#glint-mask)">Gold</text>
-          </svg>
+          The <span class="gold-glint">Gold</span> Standard
         </h1>
         <p class="mt-6 text-lg text-neutral-300">
           Welcome to RD9 Automotive, Porsche and Prestige vehicle specialists. We feel that, for too long, the motor trade has fallen short, and we are here to change that.


### PR DESCRIPTION
## Summary
- Replace SVG-based "Gold Standard" header with inline text
- Add `.gold-glint` class that animates a 1px drop-shadow for a moving glint effect

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b9ea9d2c832486a7fd51bbfae6a9