### PR TITLE
feat: add subtle gold text shine

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,29 @@
       50% { background-position: 100% 50%; }
       100% { background-position: 0% 50%; }
     }
+
+    .gold-shine {
+      position: relative;
+      display: inline-block;
+      overflow: hidden;
+      vertical-align: bottom;
+    }
+
+    .gold-shine::after {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: -100%;
+      width: 100%;
+      height: 100%;
+      background: linear-gradient(120deg, transparent, rgba(255,255,255,0.6), transparent);
+      animation: goldShine 3s linear infinite;
+    }
+
+    @keyframes goldShine {
+      0% { left: -100%; }
+      100% { left: 100%; }
+    }
   </style>
 </head>
 <body id="home" class="bg-neutral-950 text-neutral-100 antialiased min-vh-100 pt-16" style="padding-top: calc(env(safe-area-inset-top) + 4rem);">
@@ -154,7 +177,7 @@
       <div class="max-w-3xl animate-rise">
         <h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold tracking-tight text-white">
           <span class="sr-only">The Gold Standard</span>
-            The <span class="text-brand">Gold</span> Standard
+            The <span class="text-brand gold-shine">Gold</span> Standard
         </h1>
         <p class="mt-6 text-lg text-neutral-300">
           Welcome to RD9 Automotive, Porsche and Prestige vehicle specialists. We feel that, for too long, the motor trade has fallen short, and we are here to change that.
@@ -724,7 +747,7 @@
       <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-white">About</h2>
       <div class="mt-6 grid gap-10 lg:grid-cols-3 lg:items-start">
         <div class="space-y-4 text-neutral-300 lg:col-span-2">
-          <p><strong>The Gold Standard</strong><br>RD9 was founded in 2020 by Ryan Day. Ryan started his career at Porsche back in 2007 where he went through his apprenticeship all the way to achieving the gold certification in 2018. Over the last year he’s been venturing into other prestigious manufactures from lotus to Lamborghini. Now his goal is to take what he thinks works from the main dealers and add the personal touch that’s much needed.</p>
+          <p><strong>The <span class="text-brand gold-shine">Gold</span> Standard</strong><br>RD9 was founded in 2020 by Ryan Day. Ryan started his career at Porsche back in 2007 where he went through his apprenticeship all the way to achieving the <span class="text-brand gold-shine">gold</span> certification in 2018. Over the last year he’s been venturing into other prestigious manufactures from lotus to Lamborghini. Now his goal is to take what he thinks works from the main dealers and add the personal touch that’s much needed.</p>
         </div>
         <div>
           <img src="66e04639cc2cc749eb6111c2_62eaa221af55929f9612ef9a_Untitled.jpeg" alt="RD9 workshop" class="rounded-lg shadow-lg mx-auto lg:mx-0" />


### PR DESCRIPTION
## Summary
- animate gold text with inline shimmer effect
- highlight "gold" references with reusable gold-shine class

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baa7ee46a48324b997b774d911d5ca