### PR TITLE
feat: add 3D oscillating gold shield

### DIFF
--- a/hero-shield.svg
+++ b/hero-shield.svg
@@ -6,5 +6,7 @@
       <stop offset="100%" stop-color="#b8860b"/>
     </linearGradient>
   </defs>
-  <path fill="url(#gold)" d="M50 0 L90 20 V70 Q90 90 50 120 Q10 90 10 70 V20 Z"/>
+  <path id="outer" fill="url(#gold)" d="M50 0 L90 20 V70 Q90 90 50 120 Q10 90 10 70 V20 Z"/>
+  <path fill="none" stroke="#ffffff" stroke-opacity="0.4" stroke-width="2" d="M50 5 L85 23 V68 Q85 85 50 115 Q15 85 15 68 V23 Z"/>
+  <path fill="#ffffff" fill-opacity="0.5" d="M50 40 L60 50 L50 60 L40 50 Z"/>
 </svg>

--- a/index.html
+++ b/index.html
@@ -141,16 +141,10 @@
       100% { left: 100%; }
     }
 
-    .shield {
+    #shieldContainer canvas {
       width: 100%;
       height: 100%;
-      transform-origin: center;
-      animation: shieldRotate 20s linear infinite;
-    }
-
-    @keyframes shieldRotate {
-      from { transform: rotateY(0deg); }
-      to { transform: rotateY(360deg); }
+      display: block;
     }
   </style>
 </head>
@@ -226,9 +220,7 @@
           </div>
         </div>
         <div class="mt-12 lg:mt-0 lg:ml-8 flex justify-center">
-          <div class="shield-glint w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64">
-            <img src="hero-shield.svg" alt="" class="shield" />
-          </div>
+          <div id="shieldContainer" class="shield-glint w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64"></div>
         </div>
       </div>
     </div>
@@ -1254,6 +1246,53 @@
       overlay.addEventListener('click', closeMenu);
       mobileMenu.querySelectorAll('a').forEach(a => a.addEventListener('click', closeMenu));
     })();
+  </script>
+  <script type="module">
+    import * as THREE from 'https://unpkg.com/three@0.156.1/build/three.module.js';
+    import { SVGLoader } from 'https://unpkg.com/three@0.156.1/examples/jsm/loaders/SVGLoader.js';
+    const container = document.getElementById('shieldContainer');
+    if (container) {
+      const width = container.clientWidth;
+      const height = container.clientHeight;
+      const scene = new THREE.Scene();
+      const camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
+      camera.position.z = 150;
+      const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
+      renderer.setSize(width, height);
+      container.innerHTML = '';
+      container.appendChild(renderer.domElement);
+      const ambient = new THREE.AmbientLight(0xffffff, 0.8);
+      scene.add(ambient);
+      const point = new THREE.PointLight(0xffffff, 1);
+      point.position.set(100, 100, 100);
+      scene.add(point);
+      const loader = new SVGLoader();
+      const texLoader = new THREE.TextureLoader();
+      Promise.all([
+        new Promise(res => loader.load('hero-shield.svg', res)),
+        new Promise(res => texLoader.load('hero-shield.svg', res))
+      ]).then(([data, texture]) => {
+        const shapes = data.paths[0].toShapes(true);
+        const geometry = new THREE.ExtrudeGeometry(shapes, {
+          depth: 8,
+          bevelEnabled: true,
+          bevelThickness: 1,
+          bevelSize: 1,
+          bevelSegments: 2,
+        });
+        geometry.center();
+        const front = new THREE.MeshStandardMaterial({ map: texture, metalness: 1, roughness: 0.2 });
+        const side = new THREE.MeshStandardMaterial({ color: 0xb8860b, metalness: 1, roughness: 0.3 });
+        const mesh = new THREE.Mesh(geometry, [front, side]);
+        scene.add(mesh);
+        function animate(time = 0) {
+          requestAnimationFrame(animate);
+          mesh.rotation.y = Math.sin(time * 0.001) * THREE.MathUtils.degToRad(20);
+          renderer.render(scene, camera);
+        }
+        animate();
+      });
+    }
   </script>
   <script>
     (function () {


### PR DESCRIPTION
## Summary
- Replace static shield image with Three.js canvas for richer 3D rendering
- Add subtle face details and depth to the gold shield SVG
- Oscillate shield rotation between ±20° for back-and-forth animation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bab1b5068483248b04011804b7469c