### PR TITLE
Adjust gold shine opacity and fix shield rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
         90deg,
         rgba(255,255,255,0) 0%,
         rgba(255,255,255,0) 49%,
-        rgba(255,255,255,0.15) 50%,
+        rgba(255,255,255,0.5) 50%,
         rgba(255,255,255,0) 51%,
         rgba(255,255,255,0) 100%
       );
@@ -1240,6 +1240,7 @@
       const scene = new THREE.Scene();
       const camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
       camera.position.z = 150;
+      camera.lookAt(0, 0, 0);
       const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
       renderer.setSize(width, height);
       container.innerHTML = '';
@@ -1251,7 +1252,11 @@
       scene.add(point);
       const loader = new SVGLoader();
       loader.load('hero-shield.svg', data => {
-        const shapes = data.paths[0].toShapes(true);
+        const shapes = [];
+        data.paths.forEach(path => {
+          const shapesForPath = SVGLoader.createShapes(path);
+          shapes.push(...shapesForPath);
+        });
         const geometry = new THREE.ExtrudeGeometry(shapes, {
           depth: 8,
           bevelEnabled: true,
@@ -1263,6 +1268,7 @@
         const front = new THREE.MeshStandardMaterial({ color: 0xffd700, metalness: 1, roughness: 0.2 });
         const side = new THREE.MeshStandardMaterial({ color: 0xb8860b, metalness: 1, roughness: 0.3 });
         const mesh = new THREE.Mesh(geometry, [front, side]);
+        mesh.scale.y = -1;
         scene.add(mesh);
         function animate(time = 0) {
           requestAnimationFrame(animate);


### PR DESCRIPTION
## Summary
- Increase white band opacity in gold-shine effect for stronger highlight
- Fix 3D shield visibility by refining SVG shape loading, orienting mesh, and ensuring camera targets scene

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/RD9-site/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68bab525b12c8324bee1d09c334271a8