### PR TITLE
Fix Lottie animation path for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
           </div>
         </div>
         <div class="mt-12 lg:mt-0 lg:ml-8 flex justify-center">
-          <lottie-player id="steeringWheel" src="porsche-steering-wheel.json" background="transparent" speed="1" loop autoplay class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64"></lottie-player>
+          <lottie-player id="steeringWheel" src="/RD9-site/porsche-steering-wheel.json" background="transparent" speed="1" loop autoplay class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64"></lottie-player>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Use an absolute path for the steering wheel Lottie animation so GitHub Pages serves it correctly

## Testing
- `curl -I http://localhost:8000/RD9-site/porsche-steering-wheel.json`


------
https://chatgpt.com/codex/tasks/task_e_68baefa1aff08324b13b0dfbc372a33a