### PR TITLE
Ensure consistent spacing at bottom of mobile menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
   <div id="mobileMenu" class="fixed inset-0 z-30 hidden">
     <div id="menuOverlay" class="absolute inset-0 bg-black/50"></div>
     <nav id="menuPanel" class="absolute top-0 left-0 w-full bg-neutral-950 p-6 transform -translate-y-full transition-transform duration-300" style="padding-top: calc(4rem + var(--safe-top)); padding-bottom: var(--safe-bottom);">
-      <ul class="mt-12 space-y-4 text-lg">
+      <ul class="mt-12 space-y-4 text-lg pb-12">
         <li><a href="#services" class="block">Services</a></li>
         <li><a href="#prices" class="block">Prices</a></li>
         <li><a href="#about" class="block">About</a></li>


### PR DESCRIPTION
## Summary
- add bottom padding to the mobile menu list for balanced spacing

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb40324a788324881dcbb3fa142b20