### PR TITLE
Remove duplicate Gold Standard tagline from About section

### DIFF
--- a/index.html
+++ b/index.html
@@ -761,7 +761,7 @@
       <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-white">About</h2>
       <div class="mt-6 grid gap-10 lg:grid-cols-3 lg:items-start">
         <div class="space-y-4 text-neutral-300 lg:col-span-2">
-          <p><strong>The <span class="text-brand gold-shine">Gold</span> Standard</strong><br>RD9 was founded in 2020 by Ryan Day. Ryan started his career at Porsche back in 2007 where he went through his apprenticeship all the way to achieving the <span class="text-brand gold-shine">gold</span> certification in 2018. Over the last year he’s been venturing into other prestigious manufactures from lotus to Lamborghini. Now his goal is to take what he thinks works from the main dealers and add the personal touch that’s much needed.</p>
+          <p>RD9 was founded in 2020 by Ryan Day. Ryan started his career at Porsche back in 2007 where he went through his apprenticeship all the way to achieving the <span class="text-brand gold-shine">gold</span> certification in 2018. Over the last year he’s been venturing into other prestigious manufactures from lotus to Lamborghini. Now his goal is to take what he thinks works from the main dealers and add the personal touch that’s much needed.</p>
         </div>
         <div>
           <img src="66e04639cc2cc749eb6111c2_62eaa221af55929f9612ef9a_Untitled.jpeg" alt="RD9 workshop" class="rounded-lg shadow-lg mx-auto lg:mx-0" />


### PR DESCRIPTION
## Summary
- remove repeated "The Gold Standard" tagline from About section to avoid redundancy

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb407d48788324af2472862c60b174