### PR TITLE
Avoid mobile zoom on contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -844,23 +844,23 @@
             <div id="contactFields" class="space-y-4">
               <div>
                 <label for="name" class="block text-sm font-medium">Name</label>
-                <input id="name" name="name" type="text" class="mt-2 w-full rounded-md bg-neutral-950 border border-white/15 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-white/30" />
+                <input id="name" name="name" type="text" class="mt-2 w-full rounded-md bg-neutral-950 border border-white/15 px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-white/30" />
               </div>
               <div>
                 <label for="carModel" class="block text-sm font-medium">Car model *</label>
-                <input id="carModel" name="carModel" list="carOptions" required class="mt-2 w-full rounded-md bg-neutral-950 border border-white/15 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-white/30" />
+                <input id="carModel" name="carModel" list="carOptions" required class="mt-2 w-full rounded-md bg-neutral-950 border border-white/15 px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-white/30" />
               </div>
               <div>
                 <label for="email" class="block text-sm font-medium">Email *</label>
-                <input id="email" name="email" type="email" required class="mt-2 w-full rounded-md bg-neutral-950 border border-white/15 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-white/30" />
+                <input id="email" name="email" type="email" required class="mt-2 w-full rounded-md bg-neutral-950 border border-white/15 px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-white/30" />
               </div>
               <div>
                 <label for="phone" class="block text-sm font-medium">Contact number *</label>
-                <input id="phone" name="phone" type="tel" required class="mt-2 w-full rounded-md bg-neutral-950 border border-white/15 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-white/30" />
+                <input id="phone" name="phone" type="tel" required class="mt-2 w-full rounded-md bg-neutral-950 border border-white/15 px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-white/30" />
               </div>
               <div>
                 <label for="message" class="block text-sm font-medium">Message</label>
-                <textarea id="message" name="message" rows="4" class="mt-2 w-full rounded-md bg-neutral-950 border border-white/15 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-white/30"></textarea>
+                <textarea id="message" name="message" rows="4" class="mt-2 w-full rounded-md bg-neutral-950 border border-white/15 px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-white/30"></textarea>
               </div>
               <div class="flex flex-wrap items-center gap-2">
                 <button type="submit" class="inline-flex items-center gap-2 rounded-md bg-white text-neutral-900 px-4 py-2 text-sm font-semibold hover:bg-neutral-200 focus:outline-none focus:ring-2 focus:ring-white/50">Send</button>


### PR DESCRIPTION
## Summary
- Prevent iOS Safari from zooming when contact form fields gain focus by giving inputs a 16px default font size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb42f1d9288324ad1c9c449ca03936