### PR TITLE
Add favicon and social preview metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
   <title>RD9 Automotive — Porsche & Prestige Specialists</title>
   <meta name="description" content="RD9 Automotive — Porsche and prestige vehicle specialists. Fixed-price servicing, performance, wheel alignment, EV/hybrid, and pre-purchase inspections." />
+  <link rel="icon" type="image/png" sizes="32x32" href="RD9%20Favicon.png" />
+  <link rel="apple-touch-icon" sizes="256x256" href="RD9%20Webclip.png" />
+  <link rel="apple-touch-icon" sizes="512x512" href="RD9%20Webclip%202x.png" />
+  <link rel="apple-touch-icon" sizes="1028x1028" href="RD9%20Webclip%20big.png" />
+  <meta property="og:image" content="RD9%20Open%20Graph%20Preview.png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="RD9%20Open%20Graph%20Preview.png" />
   <!-- Tailwind via CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
   <style>


### PR DESCRIPTION
## Summary
- add favicon and Apple touch icon links
- include Open Graph and Twitter image metadata

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/RD9-site/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bff63a67088324bd4b82f7536da006