### PR TITLE
Fix update workflow permissions

### DIFF
--- a/.github/workflows/update-prices.yml
+++ b/.github/workflows/update-prices.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "15 6 * * *"  # daily 06:15 UTC (~07:15 UK during winter; ~07:15-08:15 with DST)
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- grant the price list update workflow the repository permissions needed to push changes and open PRs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc037a32788324bb89c528006d523c