### PR TITLE
Flatten price list sections per variant combination

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,8 +402,8 @@
       <!-- Price lists -->
       <!-- BEGIN:PRICE_LIST -->
       <div class="mt-8 space-y-12" id="priceLists" aria-live="polite">
-        <section class="price-section hidden" data-model="taycan-4s-turbo-turbo-s">
-          <h3 class="text-2xl font-bold">Taycan 4S / Turbo / Turbo S</h3>
+        <section class="price-section hidden" data-model="taycan-4s-turbo-turbo-s-4s-turbo-turbo-s-petrol-turbo-s" data-alias="taycan-4s-turbo-turbo-s">
+          <h3 class="text-2xl font-bold">Taycan 4S / Turbo / Turbo S — Petrol (Turbo S)</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -416,8 +416,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="cayenne-958-e2-2010-2017">
-          <h3 class="text-2xl font-bold">Cayenne 958 E2 (2010–2017)</h3>
+        <section class="price-section hidden" data-model="cayenne-958-e2-2010-2017-v6-958-e2-2010-2017-petrol-v6" data-alias="cayenne-958-e2-2010-2017">
+          <h3 class="text-2xl font-bold">Cayenne 958 E2 (2010–2017) — V6 (958 E2 (2010–2017), Petrol (V6))</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -430,47 +430,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">/ S / GTS (958 E2 (2010–2017))</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
-            <table class="min-w-full table-auto text-sm">
-              <thead class="bg-neutral-900/80">
-                <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
-              </thead>
-              <tbody class="divide-y divide-white/10">
-                <tr><td class="px-4 py-3">Oil Service</td><td class="px-4 py-3">Timeline variable</td><td class="px-4 py-3">£240</td></tr>
-                <tr><td class="px-4 py-3">Minor Service</td><td class="px-4 py-3">20k miles</td><td class="px-4 py-3">£390</td></tr>
-                <tr><td class="px-4 py-3">Major Service</td><td class="px-4 py-3">40k miles</td><td class="px-4 py-3">£665</td></tr>
-              </tbody>
-            </table>
-          </div>
-          <h4 class="mt-6 font-semibold">Diesel V6 (958 E2 (2010–2017), Diesel)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
-            <table class="min-w-full table-auto text-sm">
-              <thead class="bg-neutral-900/80">
-                <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
-              </thead>
-              <tbody class="divide-y divide-white/10">
-                <tr><td class="px-4 py-3">Oil Service</td><td class="px-4 py-3">Timeline variable</td><td class="px-4 py-3">£225</td></tr>
-                <tr><td class="px-4 py-3">Minor Service</td><td class="px-4 py-3">20k miles</td><td class="px-4 py-3">£370</td></tr>
-                <tr><td class="px-4 py-3">Major Service</td><td class="px-4 py-3">40k miles</td><td class="px-4 py-3">£650</td></tr>
-              </tbody>
-            </table>
-          </div>
-          <h4 class="mt-6 font-semibold">Diesel V8 (958 E2 (2010–2017), Diesel)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
-            <table class="min-w-full table-auto text-sm">
-              <thead class="bg-neutral-900/80">
-                <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
-              </thead>
-              <tbody class="divide-y divide-white/10">
-                <tr><td class="px-4 py-3">Oil Service</td><td class="px-4 py-3">Timeline variable</td><td class="px-4 py-3">£225</td></tr>
-                <tr><td class="px-4 py-3">Minor Service</td><td class="px-4 py-3">20k miles</td><td class="px-4 py-3">£390</td></tr>
-                <tr><td class="px-4 py-3">Major Service</td><td class="px-4 py-3">40k miles</td><td class="px-4 py-3">£685</td></tr>
-              </tbody>
-            </table>
-          </div>
-          <h4 class="mt-6 font-semibold">Turbo (958 E2 (2010–2017), Petrol (Turbo))</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="cayenne-958-e2-2010-2017-s-gts-958-e2-2010-2017" data-alias="cayenne-958-e2-2010-2017">
+          <h3 class="text-2xl font-bold">Cayenne 958 E2 (2010–2017) — / S / GTS (958 E2 (2010–2017))</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -483,8 +446,53 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="cayenne-958-e2-2010-2022">
-          <h3 class="text-2xl font-bold">Cayenne 958 E2 (2010–2022)</h3>
+        <section class="price-section hidden" data-model="cayenne-958-e2-2010-2017-diesel-v6-958-e2-2010-2017-diesel" data-alias="cayenne-958-e2-2010-2017">
+          <h3 class="text-2xl font-bold">Cayenne 958 E2 (2010–2017) — Diesel V6 (958 E2 (2010–2017), Diesel)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
+            <table class="min-w-full table-auto text-sm">
+              <thead class="bg-neutral-900/80">
+                <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
+              </thead>
+              <tbody class="divide-y divide-white/10">
+                <tr><td class="px-4 py-3">Oil Service</td><td class="px-4 py-3">Timeline variable</td><td class="px-4 py-3">£225</td></tr>
+                <tr><td class="px-4 py-3">Minor Service</td><td class="px-4 py-3">20k miles</td><td class="px-4 py-3">£370</td></tr>
+                <tr><td class="px-4 py-3">Major Service</td><td class="px-4 py-3">40k miles</td><td class="px-4 py-3">£650</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+        <section class="price-section hidden" data-model="cayenne-958-e2-2010-2017-diesel-v8-958-e2-2010-2017-diesel" data-alias="cayenne-958-e2-2010-2017">
+          <h3 class="text-2xl font-bold">Cayenne 958 E2 (2010–2017) — Diesel V8 (958 E2 (2010–2017), Diesel)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
+            <table class="min-w-full table-auto text-sm">
+              <thead class="bg-neutral-900/80">
+                <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
+              </thead>
+              <tbody class="divide-y divide-white/10">
+                <tr><td class="px-4 py-3">Oil Service</td><td class="px-4 py-3">Timeline variable</td><td class="px-4 py-3">£225</td></tr>
+                <tr><td class="px-4 py-3">Minor Service</td><td class="px-4 py-3">20k miles</td><td class="px-4 py-3">£390</td></tr>
+                <tr><td class="px-4 py-3">Major Service</td><td class="px-4 py-3">40k miles</td><td class="px-4 py-3">£685</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+        <section class="price-section hidden" data-model="cayenne-958-e2-2010-2017-turbo-958-e2-2010-2017-petrol-turbo" data-alias="cayenne-958-e2-2010-2017">
+          <h3 class="text-2xl font-bold">Cayenne 958 E2 (2010–2017) — Turbo (958 E2 (2010–2017), Petrol (Turbo))</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
+            <table class="min-w-full table-auto text-sm">
+              <thead class="bg-neutral-900/80">
+                <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
+              </thead>
+              <tbody class="divide-y divide-white/10">
+                <tr><td class="px-4 py-3">Oil Service</td><td class="px-4 py-3">Timeline variable</td><td class="px-4 py-3">£240</td></tr>
+                <tr><td class="px-4 py-3">Minor Service</td><td class="px-4 py-3">20k miles</td><td class="px-4 py-3">£390</td></tr>
+                <tr><td class="px-4 py-3">Major Service</td><td class="px-4 py-3">40k miles</td><td class="px-4 py-3">£665</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+        <section class="price-section hidden" data-model="cayenne-958-e2-2010-2022-hybrid-e-hybrid-958-e2-2010-2022-hybrid" data-alias="cayenne-958-e2-2010-2022">
+          <h3 class="text-2xl font-bold">Cayenne 958 E2 (2010–2022) — Hybrid / E-Hybrid (958 E2 (2010–2022), Hybrid)</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -498,8 +506,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="cayenne-957-2008-2009">
-          <h3 class="text-2xl font-bold">Cayenne 957 (2008–2009)</h3>
+        <section class="price-section hidden" data-model="cayenne-957-2008-2009-diesel-957-2008-2009-diesel" data-alias="cayenne-957-2008-2009">
+          <h3 class="text-2xl font-bold">Cayenne 957 (2008–2009) — Diesel (957 (2008–2009), Diesel)</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -513,8 +521,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="cayenne-957-2007-2009">
-          <h3 class="text-2xl font-bold">Cayenne 957 (2007–2009)</h3>
+        <section class="price-section hidden" data-model="cayenne-957-2007-2009-turbo-957-2007-2009-petrol-turbo" data-alias="cayenne-957-2007-2009">
+          <h3 class="text-2xl font-bold">Cayenne 957 (2007–2009) — Turbo (957 (2007–2009), Petrol (Turbo))</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -528,8 +536,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="cayenne-955-2003-2009">
-          <h3 class="text-2xl font-bold">Cayenne 955 (2003–2009)</h3>
+        <section class="price-section hidden" data-model="cayenne-955-2003-2009-s-955-2003-2009" data-alias="cayenne-955-2003-2009">
+          <h3 class="text-2xl font-bold">Cayenne 955 (2003–2009) — S (955 (2003–2009))</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -542,8 +550,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">V6 (955 (2003–2009), Petrol (V6))</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="cayenne-955-2003-2009-v6-955-2003-2009-petrol-v6" data-alias="cayenne-955-2003-2009">
+          <h3 class="text-2xl font-bold">Cayenne 955 (2003–2009) — V6 (955 (2003–2009), Petrol (V6))</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -555,8 +565,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo (955 (2003–2009), Petrol (Turbo))</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="cayenne-955-2003-2009-turbo-955-2003-2009-petrol-turbo" data-alias="cayenne-955-2003-2009">
+          <h3 class="text-2xl font-bold">Cayenne 955 (2003–2009) — Turbo (955 (2003–2009), Petrol (Turbo))</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -569,8 +581,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="cayenne-957-2008-2010">
-          <h3 class="text-2xl font-bold">Cayenne 957 (2008–2010)</h3>
+        <section class="price-section hidden" data-model="cayenne-957-2008-2010-s-957-2008-2010" data-alias="cayenne-957-2008-2010">
+          <h3 class="text-2xl font-bold">Cayenne 957 (2008–2010) — S (957 (2008–2010))</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -584,8 +596,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="macan-2014-2024">
-          <h3 class="text-2xl font-bold">Macan (2014–2024)</h3>
+        <section class="price-section hidden" data-model="macan-2014-2024-base-2014-2024" data-alias="macan-2014-2024">
+          <h3 class="text-2xl font-bold">Macan (2014–2024) — Base (2014–2024)</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -601,8 +613,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Base (2014–2024, PDK)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="macan-2014-2024-base-2014-2024-pdk" data-alias="macan-2014-2024">
+          <h3 class="text-2xl font-bold">Macan (2014–2024) — Base (2014–2024, PDK)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -612,8 +626,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo / GTS (2014–2024, Petrol (Turbo))</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="macan-2014-2024-turbo-gts-2014-2024-petrol-turbo" data-alias="macan-2014-2024">
+          <h3 class="text-2xl font-bold">Macan (2014–2024) — Turbo / GTS (2014–2024, Petrol (Turbo))</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -628,8 +644,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo / GTS (2014–2024, Petrol (Turbo), PDK)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="macan-2014-2024-turbo-gts-2014-2024-petrol-turbo-pdk" data-alias="macan-2014-2024">
+          <h3 class="text-2xl font-bold">Macan (2014–2024) — Turbo / GTS (2014–2024, Petrol (Turbo), PDK)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -639,8 +657,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">S (2014–2024)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="macan-2014-2024-s-2014-2024" data-alias="macan-2014-2024">
+          <h3 class="text-2xl font-bold">Macan (2014–2024) — S (2014–2024)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -653,7 +673,7 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="panamera-v6-v8">
+        <section class="price-section hidden" data-model="panamera-v6-v8-v6-v8" data-alias="panamera-v6-v8">
           <h3 class="text-2xl font-bold">Panamera V6 / V8</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
@@ -670,8 +690,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">PDK</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="panamera-v6-v8-v6-v8-pdk" data-alias="panamera-v6-v8">
+          <h3 class="text-2xl font-bold">Panamera V6 / V8 — PDK</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -682,8 +704,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="panamera-turbo">
-          <h3 class="text-2xl font-bold">Panamera Turbo</h3>
+        <section class="price-section hidden" data-model="panamera-turbo-turbo-petrol-turbo" data-alias="panamera-turbo">
+          <h3 class="text-2xl font-bold">Panamera Turbo — Petrol (Turbo)</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -697,8 +719,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Petrol (Turbo), PDK</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="panamera-turbo-turbo-petrol-turbo-pdk" data-alias="panamera-turbo">
+          <h3 class="text-2xl font-bold">Panamera Turbo — Petrol (Turbo), PDK</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -709,8 +733,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="panamera-diesel">
-          <h3 class="text-2xl font-bold">Panamera Diesel</h3>
+        <section class="price-section hidden" data-model="panamera-diesel-diesel-diesel" data-alias="panamera-diesel">
+          <h3 class="text-2xl font-bold">Panamera Diesel — Diesel</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -724,8 +748,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Diesel, PDK</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="panamera-diesel-diesel-diesel-pdk" data-alias="panamera-diesel">
+          <h3 class="text-2xl font-bold">Panamera Diesel — Diesel, PDK</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -736,8 +762,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="panamera-hybrid-e-hybrid">
-          <h3 class="text-2xl font-bold">Panamera Hybrid / E-Hybrid</h3>
+        <section class="price-section hidden" data-model="panamera-hybrid-e-hybrid-hybrid-e-hybrid-hybrid" data-alias="panamera-hybrid-e-hybrid">
+          <h3 class="text-2xl font-bold">Panamera Hybrid / E-Hybrid — Hybrid</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -751,8 +777,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Hybrid, PDK</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="panamera-hybrid-e-hybrid-hybrid-e-hybrid-hybrid-pdk" data-alias="panamera-hybrid-e-hybrid">
+          <h3 class="text-2xl font-bold">Panamera Hybrid / E-Hybrid — Hybrid, PDK</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -763,8 +791,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="cayman-718">
-          <h3 class="text-2xl font-bold">Cayman (718)</h3>
+        <section class="price-section hidden" data-model="cayman-718-718-2017-2022" data-alias="cayman-718">
+          <h3 class="text-2xl font-bold">Cayman (718) — 2017–2022</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -781,8 +809,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">2017–2022, Manual</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="cayman-718-718-2017-2022-manual" data-alias="cayman-718">
+          <h3 class="text-2xl font-bold">Cayman (718) — 2017–2022, Manual</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -792,8 +822,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">2017–2022, PDK</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="cayman-718-718-2017-2022-pdk" data-alias="cayman-718">
+          <h3 class="text-2xl font-bold">Cayman (718) — 2017–2022, PDK</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -804,8 +836,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="cayman-987">
-          <h3 class="text-2xl font-bold">Cayman (987)</h3>
+        <section class="price-section hidden" data-model="cayman-987-987-gen-2-2009-2012" data-alias="cayman-987">
+          <h3 class="text-2xl font-bold">Cayman (987) — Gen 2 (2009–2012)</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -820,8 +852,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Gen 2 (2009–2012, Manual)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="cayman-987-987-gen-2-2009-2012-manual" data-alias="cayman-987">
+          <h3 class="text-2xl font-bold">Cayman (987) — Gen 2 (2009–2012, Manual)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -831,8 +865,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Gen 2 (2009–2012, PDK)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="cayman-987-987-gen-2-2009-2012-pdk" data-alias="cayman-987">
+          <h3 class="text-2xl font-bold">Cayman (987) — Gen 2 (2009–2012, PDK)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -842,8 +878,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Gen 1 (2005–2008)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="cayman-987-987-gen-1-2005-2008" data-alias="cayman-987">
+          <h3 class="text-2xl font-bold">Cayman (987) — Gen 1 (2005–2008)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -858,8 +896,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="cayman-981">
-          <h3 class="text-2xl font-bold">Cayman (981)</h3>
+        <section class="price-section hidden" data-model="cayman-981-981-2013-2016" data-alias="cayman-981">
+          <h3 class="text-2xl font-bold">Cayman (981) — 2013–2016</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -875,8 +913,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">2013–2016, Manual</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="cayman-981-981-2013-2016-manual" data-alias="cayman-981">
+          <h3 class="text-2xl font-bold">Cayman (981) — 2013–2016, Manual</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -886,8 +926,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">2013–2016, PDK</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="cayman-981-981-2013-2016-pdk" data-alias="cayman-981">
+          <h3 class="text-2xl font-bold">Cayman (981) — 2013–2016, PDK</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -898,8 +940,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="boxster-718">
-          <h3 class="text-2xl font-bold">Boxster (718)</h3>
+        <section class="price-section hidden" data-model="boxster-718-718-2017-2022" data-alias="boxster-718">
+          <h3 class="text-2xl font-bold">Boxster (718) — 2017–2022</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -916,8 +958,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">2017–2022, Manual</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="boxster-718-718-2017-2022-manual" data-alias="boxster-718">
+          <h3 class="text-2xl font-bold">Boxster (718) — 2017–2022, Manual</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -927,8 +971,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">2017–2022, PDK</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="boxster-718-718-2017-2022-pdk" data-alias="boxster-718">
+          <h3 class="text-2xl font-bold">Boxster (718) — 2017–2022, PDK</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -939,8 +985,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="boxster-987">
-          <h3 class="text-2xl font-bold">Boxster (987)</h3>
+        <section class="price-section hidden" data-model="boxster-987-987-gen-2-2009-2012" data-alias="boxster-987">
+          <h3 class="text-2xl font-bold">Boxster (987) — Gen 2 (2009–2012)</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -955,8 +1001,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Gen 2 (2009–2012, Manual)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="boxster-987-987-gen-2-2009-2012-manual" data-alias="boxster-987">
+          <h3 class="text-2xl font-bold">Boxster (987) — Gen 2 (2009–2012, Manual)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -966,8 +1014,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Gen 2 (2009–2012, PDK)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="boxster-987-987-gen-2-2009-2012-pdk" data-alias="boxster-987">
+          <h3 class="text-2xl font-bold">Boxster (987) — Gen 2 (2009–2012, PDK)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -978,8 +1028,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="boxster-986">
-          <h3 class="text-2xl font-bold">Boxster (986)</h3>
+        <section class="price-section hidden" data-model="boxster-986-986-1998-2004" data-alias="boxster-986">
+          <h3 class="text-2xl font-bold">Boxster (986) — 1998–2004</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -996,8 +1046,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="boxster-981">
-          <h3 class="text-2xl font-bold">Boxster (981)</h3>
+        <section class="price-section hidden" data-model="boxster-981-981-2013-2016" data-alias="boxster-981">
+          <h3 class="text-2xl font-bold">Boxster (981) — 2013–2016</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -1013,8 +1063,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">2013–2016, Manual</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="boxster-981-981-2013-2016-manual" data-alias="boxster-981">
+          <h3 class="text-2xl font-bold">Boxster (981) — 2013–2016, Manual</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1024,8 +1076,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">2013–2016, PDK</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="boxster-981-981-2013-2016-pdk" data-alias="boxster-981">
+          <h3 class="text-2xl font-bold">Boxster (981) — 2013–2016, PDK</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1036,8 +1090,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="911-992">
-          <h3 class="text-2xl font-bold">911 (992)</h3>
+        <section class="price-section hidden" data-model="911-992-992-carrera-carrera-s-2019-2022" data-alias="911-992">
+          <h3 class="text-2xl font-bold">911 (992) — Carrera / Carrera S (2019–2022)</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -1053,8 +1107,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Carrera / Carrera S (2019–2022, Manual)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-992-992-carrera-carrera-s-2019-2022-manual" data-alias="911-992">
+          <h3 class="text-2xl font-bold">911 (992) — Carrera / Carrera S (2019–2022, Manual)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1064,8 +1120,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Carrera / Carrera S (2019–2022, PDK)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-992-992-carrera-carrera-s-2019-2022-pdk" data-alias="911-992">
+          <h3 class="text-2xl font-bold">911 (992) — Carrera / Carrera S (2019–2022, PDK)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1075,8 +1133,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Carrera 4 / 4S (2019–2022)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-992-992-carrera-4-4s-2019-2022" data-alias="911-992">
+          <h3 class="text-2xl font-bold">911 (992) — Carrera 4 / 4S (2019–2022)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1091,8 +1151,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Carrera 4 / 4S (2019–2022, Manual)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-992-992-carrera-4-4s-2019-2022-manual" data-alias="911-992">
+          <h3 class="text-2xl font-bold">911 (992) — Carrera 4 / 4S (2019–2022, Manual)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1102,8 +1164,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Carrera 4 / 4S (2019–2022, PDK)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-992-992-carrera-4-4s-2019-2022-pdk" data-alias="911-992">
+          <h3 class="text-2xl font-bold">911 (992) — Carrera 4 / 4S (2019–2022, PDK)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1113,8 +1177,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo / Turbo S (2020–2022, Petrol (Turbo S))</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-992-992-turbo-turbo-s-2020-2022-petrol-turbo-s" data-alias="911-992">
+          <h3 class="text-2xl font-bold">911 (992) — Turbo / Turbo S (2020–2022, Petrol (Turbo S))</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1129,8 +1195,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo / Turbo S (2020–2022, Petrol (Turbo S), Manual)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-992-992-turbo-turbo-s-2020-2022-petrol-turbo-s-manual" data-alias="911-992">
+          <h3 class="text-2xl font-bold">911 (992) — Turbo / Turbo S (2020–2022, Petrol (Turbo S), Manual)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1140,8 +1208,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo / Turbo S (2020–2022, Petrol (Turbo S), PDK)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-992-992-turbo-turbo-s-2020-2022-petrol-turbo-s-pdk" data-alias="911-992">
+          <h3 class="text-2xl font-bold">911 (992) — Turbo / Turbo S (2020–2022, Petrol (Turbo S), PDK)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1151,8 +1221,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">GT3 / GT3 RS (2021–2022, Petrol (GT))</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-992-992-gt3-gt3-rs-2021-2022-petrol-gt" data-alias="911-992">
+          <h3 class="text-2xl font-bold">911 (992) — GT3 / GT3 RS (2021–2022, Petrol (GT))</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1167,8 +1239,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">GT3 / GT3 RS (2021–2022, Petrol (GT), Manual)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-992-992-gt3-gt3-rs-2021-2022-petrol-gt-manual" data-alias="911-992">
+          <h3 class="text-2xl font-bold">911 (992) — GT3 / GT3 RS (2021–2022, Petrol (GT), Manual)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1178,8 +1252,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">GT3 / GT3 RS (2021–2022, Petrol (GT), PDK)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-992-992-gt3-gt3-rs-2021-2022-petrol-gt-pdk" data-alias="911-992">
+          <h3 class="text-2xl font-bold">911 (992) — GT3 / GT3 RS (2021–2022, Petrol (GT), PDK)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1190,8 +1266,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="911-991">
-          <h3 class="text-2xl font-bold">911 (991)</h3>
+        <section class="price-section hidden" data-model="911-991-991-gen-1-2011-2016" data-alias="911-991">
+          <h3 class="text-2xl font-bold">911 (991) — Gen 1 (2011–2016)</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -1207,8 +1283,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Gen 1 (2011–2016, Manual)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-991-991-gen-1-2011-2016-manual" data-alias="911-991">
+          <h3 class="text-2xl font-bold">911 (991) — Gen 1 (2011–2016, Manual)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1218,8 +1296,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Gen 1 (2011–2016, PDK)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-991-991-gen-1-2011-2016-pdk" data-alias="911-991">
+          <h3 class="text-2xl font-bold">911 (991) — Gen 1 (2011–2016, PDK)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1229,8 +1309,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">GT3 / RS Gen 1 (Petrol (GT))</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-991-991-gt3-rs-gen-1-petrol-gt" data-alias="911-991">
+          <h3 class="text-2xl font-bold">911 (991) — GT3 / RS Gen 1 (Petrol (GT))</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1246,8 +1328,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">GT3 / RS Gen 1 (Petrol (GT), Manual)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-991-991-gt3-rs-gen-1-petrol-gt-manual" data-alias="911-991">
+          <h3 class="text-2xl font-bold">911 (991) — GT3 / RS Gen 1 (Petrol (GT), Manual)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1257,8 +1341,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">GT3 / RS Gen 1 (Petrol (GT), PDK)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-991-991-gt3-rs-gen-1-petrol-gt-pdk" data-alias="911-991">
+          <h3 class="text-2xl font-bold">911 (991) — GT3 / RS Gen 1 (Petrol (GT), PDK)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1268,8 +1354,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo Gen 1 &amp; 2 (Petrol (Turbo))</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-991-991-turbo-gen-1-2-petrol-turbo" data-alias="911-991">
+          <h3 class="text-2xl font-bold">911 (991) — Turbo Gen 1 &amp; 2 (Petrol (Turbo))</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1284,8 +1372,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo Gen 1 &amp; 2 (Petrol (Turbo), Manual)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-991-991-turbo-gen-1-2-petrol-turbo-manual" data-alias="911-991">
+          <h3 class="text-2xl font-bold">911 (991) — Turbo Gen 1 &amp; 2 (Petrol (Turbo), Manual)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1295,8 +1385,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo Gen 1 &amp; 2 (Petrol (Turbo), PDK)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-991-991-turbo-gen-1-2-petrol-turbo-pdk" data-alias="911-991">
+          <h3 class="text-2xl font-bold">911 (991) — Turbo Gen 1 &amp; 2 (Petrol (Turbo), PDK)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1306,8 +1398,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Gen 2 (2016–2019)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-991-991-gen-2-2016-2019" data-alias="911-991">
+          <h3 class="text-2xl font-bold">911 (991) — Gen 2 (2016–2019)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1322,8 +1416,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Gen 2 (2016–2019, Manual)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-991-991-gen-2-2016-2019-manual" data-alias="911-991">
+          <h3 class="text-2xl font-bold">911 (991) — Gen 2 (2016–2019, Manual)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1333,8 +1429,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Gen 2 (2016–2019, PDK)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-991-991-gen-2-2016-2019-pdk" data-alias="911-991">
+          <h3 class="text-2xl font-bold">911 (991) — Gen 2 (2016–2019, PDK)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1345,8 +1443,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="911-997">
-          <h3 class="text-2xl font-bold">911 (997)</h3>
+        <section class="price-section hidden" data-model="911-997-997-gen-1-2004-2008" data-alias="911-997">
+          <h3 class="text-2xl font-bold">911 (997) — Gen 1 (2004–2008)</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -1362,8 +1460,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Gen 1 (2004–2008, Manual)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-997-997-gen-1-2004-2008-manual" data-alias="911-997">
+          <h3 class="text-2xl font-bold">911 (997) — Gen 1 (2004–2008, Manual)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1373,8 +1473,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Gen 1 (2004–2008, Tiptronic)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-997-997-gen-1-2004-2008-tiptronic" data-alias="911-997">
+          <h3 class="text-2xl font-bold">911 (997) — Gen 1 (2004–2008, Tiptronic)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1384,8 +1486,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Gen 2 (2008–2012)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-997-997-gen-2-2008-2012" data-alias="911-997">
+          <h3 class="text-2xl font-bold">911 (997) — Gen 2 (2008–2012)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1400,8 +1504,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Gen 2 (2008–2012, Manual)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-997-997-gen-2-2008-2012-manual" data-alias="911-997">
+          <h3 class="text-2xl font-bold">911 (997) — Gen 2 (2008–2012, Manual)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1411,8 +1517,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Gen 2 (2008–2012, PDK)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-997-997-gen-2-2008-2012-pdk" data-alias="911-997">
+          <h3 class="text-2xl font-bold">911 (997) — Gen 2 (2008–2012, PDK)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1422,8 +1530,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">GT3 / RS (2009–2012, Petrol (GT))</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-997-997-gt3-rs-2009-2012-petrol-gt" data-alias="911-997">
+          <h3 class="text-2xl font-bold">911 (997) — GT3 / RS (2009–2012, Petrol (GT))</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1438,8 +1548,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">GT3 / RS (2009–2012, Petrol (GT), Manual)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-997-997-gt3-rs-2009-2012-petrol-gt-manual" data-alias="911-997">
+          <h3 class="text-2xl font-bold">911 (997) — GT3 / RS (2009–2012, Petrol (GT), Manual)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1449,8 +1561,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo / GT2 Gen 1 (2005–2008, Petrol (Turbo))</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-997-997-turbo-gt2-gen-1-2005-2008-petrol-turbo" data-alias="911-997">
+          <h3 class="text-2xl font-bold">911 (997) — Turbo / GT2 Gen 1 (2005–2008, Petrol (Turbo))</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1465,8 +1579,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo / GT2 Gen 1 (2005–2008, Petrol (Turbo), Manual)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-997-997-turbo-gt2-gen-1-2005-2008-petrol-turbo-manual" data-alias="911-997">
+          <h3 class="text-2xl font-bold">911 (997) — Turbo / GT2 Gen 1 (2005–2008, Petrol (Turbo), Manual)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1476,8 +1592,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo / GT2 Gen 1 (2005–2008, Petrol (Turbo), Tiptronic)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-997-997-turbo-gt2-gen-1-2005-2008-petrol-turbo-tiptronic" data-alias="911-997">
+          <h3 class="text-2xl font-bold">911 (997) — Turbo / GT2 Gen 1 (2005–2008, Petrol (Turbo), Tiptronic)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1487,8 +1605,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo / GT2 Gen 2 (2010–2012, Petrol (Turbo))</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-997-997-turbo-gt2-gen-2-2010-2012-petrol-turbo" data-alias="911-997">
+          <h3 class="text-2xl font-bold">911 (997) — Turbo / GT2 Gen 2 (2010–2012, Petrol (Turbo))</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1503,8 +1623,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo / GT2 Gen 2 (2010–2012, Petrol (Turbo), Manual)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-997-997-turbo-gt2-gen-2-2010-2012-petrol-turbo-manual" data-alias="911-997">
+          <h3 class="text-2xl font-bold">911 (997) — Turbo / GT2 Gen 2 (2010–2012, Petrol (Turbo), Manual)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1514,8 +1636,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo / GT2 Gen 2 (2010–2012, Petrol (Turbo), PDK)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-997-997-turbo-gt2-gen-2-2010-2012-petrol-turbo-pdk" data-alias="911-997">
+          <h3 class="text-2xl font-bold">911 (997) — Turbo / GT2 Gen 2 (2010–2012, Petrol (Turbo), PDK)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1526,8 +1650,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="911-996">
-          <h3 class="text-2xl font-bold">911 (996)</h3>
+        <section class="price-section hidden" data-model="911-996-996-1998-2004" data-alias="911-996">
+          <h3 class="text-2xl font-bold">911 (996) — 1998–2004</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -1544,8 +1668,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">1998–2004, Manual</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-996-996-1998-2004-manual" data-alias="911-996">
+          <h3 class="text-2xl font-bold">911 (996) — 1998–2004, Manual</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1555,8 +1681,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">1998–2004, Tiptronic</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-996-996-1998-2004-tiptronic" data-alias="911-996">
+          <h3 class="text-2xl font-bold">911 (996) — 1998–2004, Tiptronic</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1566,8 +1694,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">GT3 (2001–2004, Petrol (GT))</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-996-996-gt3-2001-2004-petrol-gt" data-alias="911-996">
+          <h3 class="text-2xl font-bold">911 (996) — GT3 (2001–2004, Petrol (GT))</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1580,8 +1710,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">GT3 (2001–2004, Petrol (GT), Manual)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-996-996-gt3-2001-2004-petrol-gt-manual" data-alias="911-996">
+          <h3 class="text-2xl font-bold">911 (996) — GT3 (2001–2004, Petrol (GT), Manual)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1591,8 +1723,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo / GT2 (2001–2004, Petrol (Turbo))</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-996-996-turbo-gt2-2001-2004-petrol-turbo" data-alias="911-996">
+          <h3 class="text-2xl font-bold">911 (996) — Turbo / GT2 (2001–2004, Petrol (Turbo))</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1606,8 +1740,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo / GT2 (2001–2004, Petrol (Turbo), Manual)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-996-996-turbo-gt2-2001-2004-petrol-turbo-manual" data-alias="911-996">
+          <h3 class="text-2xl font-bold">911 (996) — Turbo / GT2 (2001–2004, Petrol (Turbo), Manual)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1617,8 +1753,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo / GT2 (2001–2004, Petrol (Turbo), Tiptronic)</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-996-996-turbo-gt2-2001-2004-petrol-turbo-tiptronic" data-alias="911-996">
+          <h3 class="text-2xl font-bold">911 (996) — Turbo / GT2 (2001–2004, Petrol (Turbo), Tiptronic)</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1629,8 +1767,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="911-964">
-          <h3 class="text-2xl font-bold">911 (964)</h3>
+        <section class="price-section hidden" data-model="911-964-964-c2-c4-1989-1993" data-alias="911-964">
+          <h3 class="text-2xl font-bold">911 (964) — C2 / C4 (1989–1993)</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -1648,8 +1786,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo / RS (1989–1993, Petrol (Turbo))</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-964-964-turbo-rs-1989-1993-petrol-turbo" data-alias="911-964">
+          <h3 class="text-2xl font-bold">911 (964) — Turbo / RS (1989–1993, Petrol (Turbo))</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1664,8 +1804,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="911-993">
-          <h3 class="text-2xl font-bold">911 (993)</h3>
+        <section class="price-section hidden" data-model="911-993-993-c2-c4-1994-1997" data-alias="911-993">
+          <h3 class="text-2xl font-bold">911 (993) — C2 / C4 (1994–1997)</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -1682,8 +1822,10 @@
               </tbody>
             </table>
           </div>
-          <h4 class="mt-6 font-semibold">Turbo / S / GT2 (1995–1997, Petrol (Turbo))</h4>
-          <div class="mt-2 overflow-x-auto rounded-lg border border-white/10">
+        </section>
+        <section class="price-section hidden" data-model="911-993-993-turbo-s-gt2-1995-1997-petrol-turbo" data-alias="911-993">
+          <h3 class="text-2xl font-bold">911 (993) — Turbo / S / GT2 (1995–1997, Petrol (Turbo))</h3>
+          <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
                 <tr><th class="px-4 py-3 text-left font-semibold">Job</th><th class="px-4 py-3 text-left font-semibold">Interval</th><th class="px-4 py-3 text-left font-semibold">Price (ex-VAT)</th></tr>
@@ -1698,8 +1840,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="911-1964-1989">
-          <h3 class="text-2xl font-bold">911 (1964–1989)</h3>
+        <section class="price-section hidden" data-model="911-1964-1989-early-911-1964-1989" data-alias="911-1964-1989">
+          <h3 class="text-2xl font-bold">911 (1964–1989) — Early 911 (1964–1989)</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -1715,8 +1857,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="911-930">
-          <h3 class="text-2xl font-bold">911 (930)</h3>
+        <section class="price-section hidden" data-model="911-930-930-turbo-1975-1977-petrol-turbo" data-alias="911-930">
+          <h3 class="text-2xl font-bold">911 (930) — Turbo (1975–1977, Petrol (Turbo))</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -1732,7 +1874,7 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="944-8v">
+        <section class="price-section hidden" data-model="944-8v-8v" data-alias="944-8v">
           <h3 class="text-2xl font-bold">944 8V</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
@@ -1749,8 +1891,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="944-turbo">
-          <h3 class="text-2xl font-bold">944 Turbo</h3>
+        <section class="price-section hidden" data-model="944-turbo-turbo-petrol-turbo" data-alias="944-turbo">
+          <h3 class="text-2xl font-bold">944 Turbo — Petrol (Turbo)</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -1766,7 +1908,7 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="944-s2-16v">
+        <section class="price-section hidden" data-model="944-s2-16v-s2-16v" data-alias="944-s2-16v">
           <h3 class="text-2xl font-bold">944 S2 16V</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
@@ -1783,7 +1925,7 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="928-8v">
+        <section class="price-section hidden" data-model="928-8v-8v" data-alias="928-8v">
           <h3 class="text-2xl font-bold">928 8V</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
@@ -1801,7 +1943,7 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="928-s4-gt-gts">
+        <section class="price-section hidden" data-model="928-s4-gt-gts-s4-gt-gts" data-alias="928-s4-gt-gts">
           <h3 class="text-2xl font-bold">928 S4 / GT / GTS</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
@@ -1819,8 +1961,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="968-1992-1993">
-          <h3 class="text-2xl font-bold">968 (1992–1993)</h3>
+        <section class="price-section hidden" data-model="968-1992-1993-base-1992-1993" data-alias="968-1992-1993">
+          <h3 class="text-2xl font-bold">968 (1992–1993) — Base (1992–1993)</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -1836,8 +1978,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="968-tiptronic">
-          <h3 class="text-2xl font-bold">968 Tiptronic</h3>
+        <section class="price-section hidden" data-model="968-tiptronic-tiptronic-tiptronic" data-alias="968-tiptronic">
+          <h3 class="text-2xl font-bold">968 Tiptronic — Tiptronic</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -1853,8 +1995,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="968-1994-1995">
-          <h3 class="text-2xl font-bold">968 (1994–1995)</h3>
+        <section class="price-section hidden" data-model="968-1994-1995-base-1994-1995" data-alias="968-1994-1995">
+          <h3 class="text-2xl font-bold">968 (1994–1995) — Base (1994–1995)</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -1870,7 +2012,7 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="924-base">
+        <section class="price-section hidden" data-model="924-base-base" data-alias="924-base">
           <h3 class="text-2xl font-bold">924 Base</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
@@ -1887,8 +2029,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="924-turbo-gt-gts">
-          <h3 class="text-2xl font-bold">924 Turbo / GT / GTS</h3>
+        <section class="price-section hidden" data-model="924-turbo-gt-gts-turbo-gt-gts-petrol-turbo" data-alias="924-turbo-gt-gts">
+          <h3 class="text-2xl font-bold">924 Turbo / GT / GTS — Petrol (Turbo)</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">
@@ -1904,8 +2046,8 @@
             </table>
           </div>
         </section>
-        <section class="price-section hidden" data-model="924-924">
-          <h3 class="text-2xl font-bold">924</h3>
+        <section class="price-section hidden" data-model="924-924-924-s" data-alias="924-924">
+          <h3 class="text-2xl font-bold">924 — S</h3>
           <div class="mt-4 overflow-x-auto rounded-lg border border-white/10">
             <table class="min-w-full table-auto text-sm">
               <thead class="bg-neutral-900/80">

--- a/site/data/prices.json
+++ b/site/data/prices.json
@@ -1,4816 +1,5057 @@
 [
   {
-    "id": "taycan-4s-turbo-turbo-s",
-    "title": "Taycan 4S / Turbo / Turbo S",
+    "id": "taycan-4s-turbo-turbo-s-4s-turbo-turbo-s-petrol-turbo-s",
+    "title": "Taycan 4S / Turbo / Turbo S — Petrol (Turbo S)",
     "model_family": "Taycan",
     "generation": "4S / Turbo / Turbo S",
-    "variants": [
+    "variant": "4S / Turbo / Turbo S",
+    "years": "",
+    "powertrain": "Petrol (Turbo S)",
+    "transmission": "",
+    "model_slug": "taycan-4s-turbo-turbo-s",
+    "model_title": "Taycan 4S / Turbo / Turbo S",
+    "items": [
       {
-        "name": "4S / Turbo / Turbo S",
-        "heading": "Petrol (Turbo S)",
-        "years": "",
-        "powertrain": "Petrol (Turbo S)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Maintenance",
-            "interval": "20k miles",
-            "price": "£405",
-            "service_category": "Scheduled Service",
-            "service_item": "Maintenance",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "405"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Maintenance",
+        "interval": "20k miles",
+        "price": "£405",
+        "service_category": "Scheduled Service",
+        "service_item": "Maintenance",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "405"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "cayenne-958-e2-2010-2017",
-    "title": "Cayenne 958 E2 (2010–2017)",
+    "id": "cayenne-958-e2-2010-2017-v6-958-e2-2010-2017-petrol-v6",
+    "title": "Cayenne 958 E2 (2010–2017) — V6 (958 E2 (2010–2017), Petrol (V6))",
     "model_family": "Cayenne",
     "generation": "958 E2 (2010–2017)",
-    "variants": [
+    "variant": "V6",
+    "years": "958 E2 (2010–2017)",
+    "powertrain": "Petrol (V6)",
+    "transmission": "",
+    "model_slug": "cayenne-958-e2-2010-2017",
+    "model_title": "Cayenne 958 E2 (2010–2017)",
+    "items": [
       {
-        "name": "V6",
-        "heading": "V6 (958 E2 (2010–2017), Petrol (V6))",
-        "years": "958 E2 (2010–2017)",
-        "powertrain": "Petrol (V6)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£240",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "240"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£380",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "380"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£615",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "615"
-          }
-        ]
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£240",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "240"
       },
       {
-        "name": "/ S / GTS",
-        "heading": "/ S / GTS (958 E2 (2010–2017))",
-        "years": "958 E2 (2010–2017)",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£240",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "240"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£390",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "390"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£665",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "665"
-          }
-        ]
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£380",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "380"
       },
       {
-        "name": "Diesel V6",
-        "heading": "Diesel V6 (958 E2 (2010–2017), Diesel)",
-        "years": "958 E2 (2010–2017)",
-        "powertrain": "Diesel",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£225",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "225"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£370",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "370"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£650",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "650"
-          }
-        ]
-      },
-      {
-        "name": "Diesel V8",
-        "heading": "Diesel V8 (958 E2 (2010–2017), Diesel)",
-        "years": "958 E2 (2010–2017)",
-        "powertrain": "Diesel",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£225",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "225"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£390",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "390"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£685",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "685"
-          }
-        ]
-      },
-      {
-        "name": "Turbo",
-        "heading": "Turbo (958 E2 (2010–2017), Petrol (Turbo))",
-        "years": "958 E2 (2010–2017)",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£240",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "240"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£390",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "390"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£665",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "665"
-          }
-        ]
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£615",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "615"
       }
     ]
   },
   {
-    "id": "cayenne-958-e2-2010-2022",
-    "title": "Cayenne 958 E2 (2010–2022)",
+    "id": "cayenne-958-e2-2010-2017-s-gts-958-e2-2010-2017",
+    "title": "Cayenne 958 E2 (2010–2017) — / S / GTS (958 E2 (2010–2017))",
+    "model_family": "Cayenne",
+    "generation": "958 E2 (2010–2017)",
+    "variant": "/ S / GTS",
+    "years": "958 E2 (2010–2017)",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "cayenne-958-e2-2010-2017",
+    "model_title": "Cayenne 958 E2 (2010–2017)",
+    "items": [
+      {
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£240",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "240"
+      },
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£390",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "390"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£665",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "665"
+      }
+    ]
+  },
+  {
+    "id": "cayenne-958-e2-2010-2017-diesel-v6-958-e2-2010-2017-diesel",
+    "title": "Cayenne 958 E2 (2010–2017) — Diesel V6 (958 E2 (2010–2017), Diesel)",
+    "model_family": "Cayenne",
+    "generation": "958 E2 (2010–2017)",
+    "variant": "Diesel V6",
+    "years": "958 E2 (2010–2017)",
+    "powertrain": "Diesel",
+    "transmission": "",
+    "model_slug": "cayenne-958-e2-2010-2017",
+    "model_title": "Cayenne 958 E2 (2010–2017)",
+    "items": [
+      {
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£225",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "225"
+      },
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£370",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "370"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£650",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "650"
+      }
+    ]
+  },
+  {
+    "id": "cayenne-958-e2-2010-2017-diesel-v8-958-e2-2010-2017-diesel",
+    "title": "Cayenne 958 E2 (2010–2017) — Diesel V8 (958 E2 (2010–2017), Diesel)",
+    "model_family": "Cayenne",
+    "generation": "958 E2 (2010–2017)",
+    "variant": "Diesel V8",
+    "years": "958 E2 (2010–2017)",
+    "powertrain": "Diesel",
+    "transmission": "",
+    "model_slug": "cayenne-958-e2-2010-2017",
+    "model_title": "Cayenne 958 E2 (2010–2017)",
+    "items": [
+      {
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£225",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "225"
+      },
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£390",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "390"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£685",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "685"
+      }
+    ]
+  },
+  {
+    "id": "cayenne-958-e2-2010-2017-turbo-958-e2-2010-2017-petrol-turbo",
+    "title": "Cayenne 958 E2 (2010–2017) — Turbo (958 E2 (2010–2017), Petrol (Turbo))",
+    "model_family": "Cayenne",
+    "generation": "958 E2 (2010–2017)",
+    "variant": "Turbo",
+    "years": "958 E2 (2010–2017)",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "",
+    "model_slug": "cayenne-958-e2-2010-2017",
+    "model_title": "Cayenne 958 E2 (2010–2017)",
+    "items": [
+      {
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£240",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "240"
+      },
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£390",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "390"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£665",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "665"
+      }
+    ]
+  },
+  {
+    "id": "cayenne-958-e2-2010-2022-hybrid-e-hybrid-958-e2-2010-2022-hybrid",
+    "title": "Cayenne 958 E2 (2010–2022) — Hybrid / E-Hybrid (958 E2 (2010–2022), Hybrid)",
     "model_family": "Cayenne",
     "generation": "958 E2 (2010–2022)",
-    "variants": [
+    "variant": "Hybrid / E-Hybrid",
+    "years": "958 E2 (2010–2022)",
+    "powertrain": "Hybrid",
+    "transmission": "",
+    "model_slug": "cayenne-958-e2-2010-2022",
+    "model_title": "Cayenne 958 E2 (2010–2022)",
+    "items": [
       {
-        "name": "Hybrid / E-Hybrid",
-        "heading": "Hybrid / E-Hybrid (958 E2 (2010–2022), Hybrid)",
-        "years": "958 E2 (2010–2022)",
-        "powertrain": "Hybrid",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£235",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "235"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£390",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "390"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£610",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "610"
-          }
-        ]
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£235",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "235"
+      },
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£390",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "390"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£610",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "610"
       }
     ]
   },
   {
-    "id": "cayenne-957-2008-2009",
-    "title": "Cayenne 957 (2008–2009)",
+    "id": "cayenne-957-2008-2009-diesel-957-2008-2009-diesel",
+    "title": "Cayenne 957 (2008–2009) — Diesel (957 (2008–2009), Diesel)",
     "model_family": "Cayenne",
     "generation": "957 (2008–2009)",
-    "variants": [
+    "variant": "Diesel",
+    "years": "957 (2008–2009)",
+    "powertrain": "Diesel",
+    "transmission": "",
+    "model_slug": "cayenne-957-2008-2009",
+    "model_title": "Cayenne 957 (2008–2009)",
+    "items": [
       {
-        "name": "Diesel",
-        "heading": "Diesel (957 (2008–2009), Diesel)",
-        "years": "957 (2008–2009)",
-        "powertrain": "Diesel",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£225",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "225"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£295",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "295"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£650",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "650"
-          }
-        ]
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£225",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "225"
+      },
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£295",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "295"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£650",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "650"
       }
     ]
   },
   {
-    "id": "cayenne-957-2007-2009",
-    "title": "Cayenne 957 (2007–2009)",
+    "id": "cayenne-957-2007-2009-turbo-957-2007-2009-petrol-turbo",
+    "title": "Cayenne 957 (2007–2009) — Turbo (957 (2007–2009), Petrol (Turbo))",
     "model_family": "Cayenne",
     "generation": "957 (2007–2009)",
-    "variants": [
+    "variant": "Turbo",
+    "years": "957 (2007–2009)",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "",
+    "model_slug": "cayenne-957-2007-2009",
+    "model_title": "Cayenne 957 (2007–2009)",
+    "items": [
       {
-        "name": "Turbo",
-        "heading": "Turbo (957 (2007–2009), Petrol (Turbo))",
-        "years": "957 (2007–2009)",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£240",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "240"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£390",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "390"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£665",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "665"
-          }
-        ]
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£240",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "240"
+      },
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£390",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "390"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£665",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "665"
       }
     ]
   },
   {
-    "id": "cayenne-955-2003-2009",
-    "title": "Cayenne 955 (2003–2009)",
+    "id": "cayenne-955-2003-2009-s-955-2003-2009",
+    "title": "Cayenne 955 (2003–2009) — S (955 (2003–2009))",
     "model_family": "Cayenne",
     "generation": "955 (2003–2009)",
-    "variants": [
+    "variant": "S",
+    "years": "955 (2003–2009)",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "cayenne-955-2003-2009",
+    "model_title": "Cayenne 955 (2003–2009)",
+    "items": [
       {
-        "name": "S",
-        "heading": "S (955 (2003–2009))",
-        "years": "955 (2003–2009)",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£240",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "240"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£380",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "380"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£625",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "625"
-          }
-        ]
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£240",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "240"
       },
       {
-        "name": "V6",
-        "heading": "V6 (955 (2003–2009), Petrol (V6))",
-        "years": "955 (2003–2009)",
-        "powertrain": "Petrol (V6)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£240",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "240"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£380",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "380"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£625",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "625"
-          }
-        ]
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£380",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "380"
       },
       {
-        "name": "Turbo",
-        "heading": "Turbo (955 (2003–2009), Petrol (Turbo))",
-        "years": "955 (2003–2009)",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£240",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "240"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£390",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "390"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£665",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "665"
-          }
-        ]
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£625",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "625"
       }
     ]
   },
   {
-    "id": "cayenne-957-2008-2010",
-    "title": "Cayenne 957 (2008–2010)",
+    "id": "cayenne-955-2003-2009-v6-955-2003-2009-petrol-v6",
+    "title": "Cayenne 955 (2003–2009) — V6 (955 (2003–2009), Petrol (V6))",
+    "model_family": "Cayenne",
+    "generation": "955 (2003–2009)",
+    "variant": "V6",
+    "years": "955 (2003–2009)",
+    "powertrain": "Petrol (V6)",
+    "transmission": "",
+    "model_slug": "cayenne-955-2003-2009",
+    "model_title": "Cayenne 955 (2003–2009)",
+    "items": [
+      {
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£240",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "240"
+      },
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£380",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "380"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£625",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "625"
+      }
+    ]
+  },
+  {
+    "id": "cayenne-955-2003-2009-turbo-955-2003-2009-petrol-turbo",
+    "title": "Cayenne 955 (2003–2009) — Turbo (955 (2003–2009), Petrol (Turbo))",
+    "model_family": "Cayenne",
+    "generation": "955 (2003–2009)",
+    "variant": "Turbo",
+    "years": "955 (2003–2009)",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "",
+    "model_slug": "cayenne-955-2003-2009",
+    "model_title": "Cayenne 955 (2003–2009)",
+    "items": [
+      {
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£240",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "240"
+      },
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£390",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "390"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£665",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "665"
+      }
+    ]
+  },
+  {
+    "id": "cayenne-957-2008-2010-s-957-2008-2010",
+    "title": "Cayenne 957 (2008–2010) — S (957 (2008–2010))",
     "model_family": "Cayenne",
     "generation": "957 (2008–2010)",
-    "variants": [
+    "variant": "S",
+    "years": "957 (2008–2010)",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "cayenne-957-2008-2010",
+    "model_title": "Cayenne 957 (2008–2010)",
+    "items": [
       {
-        "name": "S",
-        "heading": "S (957 (2008–2010))",
-        "years": "957 (2008–2010)",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£240",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "240"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£380",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "380"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£625",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "625"
-          }
-        ]
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£240",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "240"
+      },
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£380",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "380"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£625",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "625"
       }
     ]
   },
   {
-    "id": "macan-2014-2024",
-    "title": "Macan (2014–2024)",
+    "id": "macan-2014-2024-base-2014-2024",
+    "title": "Macan (2014–2024) — Base (2014–2024)",
     "model_family": "Macan",
     "generation": "2014–2024",
-    "variants": [
+    "variant": "Base",
+    "years": "2014–2024",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "macan-2014-2024",
+    "model_title": "Macan (2014–2024)",
+    "items": [
       {
-        "name": "Base",
-        "heading": "Base (2014–2024)",
-        "years": "2014–2024",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£235",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "235"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£390",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "390"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£585",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "585"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£180",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "180"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "80k miles",
-            "price": "£75",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "80000",
-            "interval_years": "",
-            "raw_price": "75"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£235",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "235"
       },
       {
-        "name": "Base",
-        "heading": "Base (2014–2024, PDK)",
-        "years": "2014–2024",
-        "powertrain": "",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "40k miles",
-            "price": "£270",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "270"
-          }
-        ]
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£390",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "390"
       },
       {
-        "name": "Turbo / GTS",
-        "heading": "Turbo / GTS (2014–2024, Petrol (Turbo))",
-        "years": "2014–2024",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£235",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "235"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£410",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "410"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£600",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "600"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£205",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "205"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "80k miles",
-            "price": "£110",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "80000",
-            "interval_years": "",
-            "raw_price": "110"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£585",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "585"
       },
       {
-        "name": "Turbo / GTS",
-        "heading": "Turbo / GTS (2014–2024, Petrol (Turbo), PDK)",
-        "years": "2014–2024",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "40k miles",
-            "price": "£270",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "270"
-          }
-        ]
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£180",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "180"
       },
       {
-        "name": "S",
-        "heading": "S (2014–2024)",
-        "years": "2014–2024",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£235",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "235"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£410",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "410"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£585",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "585"
-          }
-        ]
+        "job": "Air Filter",
+        "interval": "80k miles",
+        "price": "£75",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "80000",
+        "interval_years": "",
+        "raw_price": "75"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "panamera-v6-v8",
+    "id": "macan-2014-2024-base-2014-2024-pdk",
+    "title": "Macan (2014–2024) — Base (2014–2024, PDK)",
+    "model_family": "Macan",
+    "generation": "2014–2024",
+    "variant": "Base",
+    "years": "2014–2024",
+    "powertrain": "",
+    "transmission": "PDK",
+    "model_slug": "macan-2014-2024",
+    "model_title": "Macan (2014–2024)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "40k miles",
+        "price": "£270",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "270"
+      }
+    ]
+  },
+  {
+    "id": "macan-2014-2024-turbo-gts-2014-2024-petrol-turbo",
+    "title": "Macan (2014–2024) — Turbo / GTS (2014–2024, Petrol (Turbo))",
+    "model_family": "Macan",
+    "generation": "2014–2024",
+    "variant": "Turbo / GTS",
+    "years": "2014–2024",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "",
+    "model_slug": "macan-2014-2024",
+    "model_title": "Macan (2014–2024)",
+    "items": [
+      {
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£235",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "235"
+      },
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£410",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "410"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£600",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "600"
+      },
+      {
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£205",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "205"
+      },
+      {
+        "job": "Air Filter",
+        "interval": "80k miles",
+        "price": "£110",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "80000",
+        "interval_years": "",
+        "raw_price": "110"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "macan-2014-2024-turbo-gts-2014-2024-petrol-turbo-pdk",
+    "title": "Macan (2014–2024) — Turbo / GTS (2014–2024, Petrol (Turbo), PDK)",
+    "model_family": "Macan",
+    "generation": "2014–2024",
+    "variant": "Turbo / GTS",
+    "years": "2014–2024",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "PDK",
+    "model_slug": "macan-2014-2024",
+    "model_title": "Macan (2014–2024)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "40k miles",
+        "price": "£270",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "270"
+      }
+    ]
+  },
+  {
+    "id": "macan-2014-2024-s-2014-2024",
+    "title": "Macan (2014–2024) — S (2014–2024)",
+    "model_family": "Macan",
+    "generation": "2014–2024",
+    "variant": "S",
+    "years": "2014–2024",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "macan-2014-2024",
+    "model_title": "Macan (2014–2024)",
+    "items": [
+      {
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£235",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "235"
+      },
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£410",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "410"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£585",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "585"
+      }
+    ]
+  },
+  {
+    "id": "panamera-v6-v8-v6-v8",
     "title": "Panamera V6 / V8",
     "model_family": "Panamera",
     "generation": "V6 / V8",
-    "variants": [
+    "variant": "V6 / V8",
+    "years": "",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "panamera-v6-v8",
+    "model_title": "Panamera V6 / V8",
+    "items": [
       {
-        "name": "V6 / V8",
-        "heading": "",
-        "years": "",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£240",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "240"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£350",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "350"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£400",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "400"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£655",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "655"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£665",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "665"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£240",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "240"
       },
       {
-        "name": "V6 / V8",
-        "heading": "PDK",
-        "years": "",
-        "powertrain": "",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Service",
-            "interval": "60k miles",
-            "price": "£695",
-            "service_category": "Transmission",
-            "service_item": "PDK Service",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "695"
-          }
-        ]
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£350",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "350"
+      },
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£400",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "400"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£655",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "655"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£665",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "665"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "panamera-turbo",
-    "title": "Panamera Turbo",
+    "id": "panamera-v6-v8-v6-v8-pdk",
+    "title": "Panamera V6 / V8 — PDK",
+    "model_family": "Panamera",
+    "generation": "V6 / V8",
+    "variant": "V6 / V8",
+    "years": "",
+    "powertrain": "",
+    "transmission": "PDK",
+    "model_slug": "panamera-v6-v8",
+    "model_title": "Panamera V6 / V8",
+    "items": [
+      {
+        "job": "PDK Service",
+        "interval": "60k miles",
+        "price": "£695",
+        "service_category": "Transmission",
+        "service_item": "PDK Service",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "695"
+      }
+    ]
+  },
+  {
+    "id": "panamera-turbo-turbo-petrol-turbo",
+    "title": "Panamera Turbo — Petrol (Turbo)",
     "model_family": "Panamera",
     "generation": "Turbo",
-    "variants": [
+    "variant": "Turbo",
+    "years": "",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "",
+    "model_slug": "panamera-turbo",
+    "model_title": "Panamera Turbo",
+    "items": [
       {
-        "name": "Turbo",
-        "heading": "Petrol (Turbo)",
-        "years": "",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£250",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "250"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£405",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "405"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£710",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "710"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£250",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "250"
       },
       {
-        "name": "Turbo",
-        "heading": "Petrol (Turbo), PDK",
-        "years": "",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Service",
-            "interval": "60k miles",
-            "price": "£695",
-            "service_category": "Transmission",
-            "service_item": "PDK Service",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "695"
-          }
-        ]
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£405",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "405"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£710",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "710"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "panamera-diesel",
-    "title": "Panamera Diesel",
+    "id": "panamera-turbo-turbo-petrol-turbo-pdk",
+    "title": "Panamera Turbo — Petrol (Turbo), PDK",
+    "model_family": "Panamera",
+    "generation": "Turbo",
+    "variant": "Turbo",
+    "years": "",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "PDK",
+    "model_slug": "panamera-turbo",
+    "model_title": "Panamera Turbo",
+    "items": [
+      {
+        "job": "PDK Service",
+        "interval": "60k miles",
+        "price": "£695",
+        "service_category": "Transmission",
+        "service_item": "PDK Service",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "695"
+      }
+    ]
+  },
+  {
+    "id": "panamera-diesel-diesel-diesel",
+    "title": "Panamera Diesel — Diesel",
     "model_family": "Panamera",
     "generation": "Diesel",
-    "variants": [
+    "variant": "Diesel",
+    "years": "",
+    "powertrain": "Diesel",
+    "transmission": "",
+    "model_slug": "panamera-diesel",
+    "model_title": "Panamera Diesel",
+    "items": [
       {
-        "name": "Diesel",
-        "heading": "Diesel",
-        "years": "",
-        "powertrain": "Diesel",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£235",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "235"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£360",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "360"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£640",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "640"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£235",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "235"
       },
       {
-        "name": "Diesel",
-        "heading": "Diesel, PDK",
-        "years": "",
-        "powertrain": "Diesel",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Service",
-            "interval": "60k miles",
-            "price": "£695",
-            "service_category": "Transmission",
-            "service_item": "PDK Service",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "695"
-          }
-        ]
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£360",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "360"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£640",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "640"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "panamera-hybrid-e-hybrid",
-    "title": "Panamera Hybrid / E-Hybrid",
+    "id": "panamera-diesel-diesel-diesel-pdk",
+    "title": "Panamera Diesel — Diesel, PDK",
+    "model_family": "Panamera",
+    "generation": "Diesel",
+    "variant": "Diesel",
+    "years": "",
+    "powertrain": "Diesel",
+    "transmission": "PDK",
+    "model_slug": "panamera-diesel",
+    "model_title": "Panamera Diesel",
+    "items": [
+      {
+        "job": "PDK Service",
+        "interval": "60k miles",
+        "price": "£695",
+        "service_category": "Transmission",
+        "service_item": "PDK Service",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "695"
+      }
+    ]
+  },
+  {
+    "id": "panamera-hybrid-e-hybrid-hybrid-e-hybrid-hybrid",
+    "title": "Panamera Hybrid / E-Hybrid — Hybrid",
     "model_family": "Panamera",
     "generation": "Hybrid / E-Hybrid",
-    "variants": [
+    "variant": "Hybrid / E-Hybrid",
+    "years": "",
+    "powertrain": "Hybrid",
+    "transmission": "",
+    "model_slug": "panamera-hybrid-e-hybrid",
+    "model_title": "Panamera Hybrid / E-Hybrid",
+    "items": [
       {
-        "name": "Hybrid / E-Hybrid",
-        "heading": "Hybrid",
-        "years": "",
-        "powertrain": "Hybrid",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Oil Service",
-            "interval": "Timeline variable",
-            "price": "£240",
-            "service_category": "Scheduled Service",
-            "service_item": "Oil Service",
-            "interval_miles": "",
-            "interval_years": "timeline variable",
-            "raw_price": "240"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£395",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "395"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£675",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "675"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Oil Service",
+        "interval": "Timeline variable",
+        "price": "£240",
+        "service_category": "Scheduled Service",
+        "service_item": "Oil Service",
+        "interval_miles": "",
+        "interval_years": "timeline variable",
+        "raw_price": "240"
       },
       {
-        "name": "Hybrid / E-Hybrid",
-        "heading": "Hybrid, PDK",
-        "years": "",
-        "powertrain": "Hybrid",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Service",
-            "interval": "60k miles",
-            "price": "£695",
-            "service_category": "Transmission",
-            "service_item": "PDK Service",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "695"
-          }
-        ]
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£395",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "395"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£675",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "675"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "cayman-718",
-    "title": "Cayman (718)",
+    "id": "panamera-hybrid-e-hybrid-hybrid-e-hybrid-hybrid-pdk",
+    "title": "Panamera Hybrid / E-Hybrid — Hybrid, PDK",
+    "model_family": "Panamera",
+    "generation": "Hybrid / E-Hybrid",
+    "variant": "Hybrid / E-Hybrid",
+    "years": "",
+    "powertrain": "Hybrid",
+    "transmission": "PDK",
+    "model_slug": "panamera-hybrid-e-hybrid",
+    "model_title": "Panamera Hybrid / E-Hybrid",
+    "items": [
+      {
+        "job": "PDK Service",
+        "interval": "60k miles",
+        "price": "£695",
+        "service_category": "Transmission",
+        "service_item": "PDK Service",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "695"
+      }
+    ]
+  },
+  {
+    "id": "cayman-718-718-2017-2022",
+    "title": "Cayman (718) — 2017–2022",
     "model_family": "Cayman",
     "generation": "718",
-    "variants": [
+    "variant": "718",
+    "years": "2017–2022",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "cayman-718",
+    "model_title": "Cayman (718)",
+    "items": [
       {
-        "name": "718",
-        "heading": "2017–2022",
-        "years": "2017–2022",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£380",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "380"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£550",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "550"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£165",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "165"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£215",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "215"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "60k miles",
-            "price": "£140",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "140"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£140",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "140"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£380",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "380"
       },
       {
-        "name": "718",
-        "heading": "2017–2022, Manual",
-        "years": "2017–2022",
-        "powertrain": "",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox Oil",
-            "interval": "120k miles",
-            "price": "£90",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "90"
-          }
-        ]
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£550",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "550"
       },
       {
-        "name": "718",
-        "heading": "2017–2022, PDK",
-        "years": "2017–2022",
-        "powertrain": "",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "120k miles",
-            "price": "£210",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "210"
-          }
-        ]
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£165",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "165"
+      },
+      {
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£215",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "215"
+      },
+      {
+        "job": "Air Filter",
+        "interval": "60k miles",
+        "price": "£140",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "140"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£140",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "140"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "cayman-987",
-    "title": "Cayman (987)",
+    "id": "cayman-718-718-2017-2022-manual",
+    "title": "Cayman (718) — 2017–2022, Manual",
+    "model_family": "Cayman",
+    "generation": "718",
+    "variant": "718",
+    "years": "2017–2022",
+    "powertrain": "",
+    "transmission": "Manual",
+    "model_slug": "cayman-718",
+    "model_title": "Cayman (718)",
+    "items": [
+      {
+        "job": "Manual Gearbox Oil",
+        "interval": "120k miles",
+        "price": "£90",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "90"
+      }
+    ]
+  },
+  {
+    "id": "cayman-718-718-2017-2022-pdk",
+    "title": "Cayman (718) — 2017–2022, PDK",
+    "model_family": "Cayman",
+    "generation": "718",
+    "variant": "718",
+    "years": "2017–2022",
+    "powertrain": "",
+    "transmission": "PDK",
+    "model_slug": "cayman-718",
+    "model_title": "Cayman (718)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "120k miles",
+        "price": "£210",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "210"
+      }
+    ]
+  },
+  {
+    "id": "cayman-987-987-gen-2-2009-2012",
+    "title": "Cayman (987) — Gen 2 (2009–2012)",
     "model_family": "Cayman",
     "generation": "987",
-    "variants": [
+    "variant": "987 Gen 2",
+    "years": "2009–2012",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "cayman-987",
+    "model_title": "Cayman (987)",
+    "items": [
       {
-        "name": "987 Gen 2",
-        "heading": "Gen 2 (2009–2012)",
-        "years": "2009–2012",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£335",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "335"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£505",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "505"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£200",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "200"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£140",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "140"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£335",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "335"
       },
       {
-        "name": "987 Gen 2",
-        "heading": "Gen 2 (2009–2012, Manual)",
-        "years": "2009–2012",
-        "powertrain": "",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox Oil",
-            "interval": "120k miles",
-            "price": "£90",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "90"
-          }
-        ]
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£505",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "505"
       },
       {
-        "name": "987 Gen 2",
-        "heading": "Gen 2 (2009–2012, PDK)",
-        "years": "2009–2012",
-        "powertrain": "",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "60k miles",
-            "price": "£210",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "210"
-          }
-        ]
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£200",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "200"
       },
       {
-        "name": "987 Gen 1",
-        "heading": "Gen 1 (2005–2008)",
-        "years": "2005–2008",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£335",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "335"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£505",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "505"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£200",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "200"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£140",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "140"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£140",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "140"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "cayman-981",
-    "title": "Cayman (981)",
+    "id": "cayman-987-987-gen-2-2009-2012-manual",
+    "title": "Cayman (987) — Gen 2 (2009–2012, Manual)",
+    "model_family": "Cayman",
+    "generation": "987",
+    "variant": "987 Gen 2",
+    "years": "2009–2012",
+    "powertrain": "",
+    "transmission": "Manual",
+    "model_slug": "cayman-987",
+    "model_title": "Cayman (987)",
+    "items": [
+      {
+        "job": "Manual Gearbox Oil",
+        "interval": "120k miles",
+        "price": "£90",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "90"
+      }
+    ]
+  },
+  {
+    "id": "cayman-987-987-gen-2-2009-2012-pdk",
+    "title": "Cayman (987) — Gen 2 (2009–2012, PDK)",
+    "model_family": "Cayman",
+    "generation": "987",
+    "variant": "987 Gen 2",
+    "years": "2009–2012",
+    "powertrain": "",
+    "transmission": "PDK",
+    "model_slug": "cayman-987",
+    "model_title": "Cayman (987)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "60k miles",
+        "price": "£210",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "210"
+      }
+    ]
+  },
+  {
+    "id": "cayman-987-987-gen-1-2005-2008",
+    "title": "Cayman (987) — Gen 1 (2005–2008)",
+    "model_family": "Cayman",
+    "generation": "987",
+    "variant": "987 Gen 1",
+    "years": "2005–2008",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "cayman-987",
+    "model_title": "Cayman (987)",
+    "items": [
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£335",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "335"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£505",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "505"
+      },
+      {
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£200",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "200"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£140",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "140"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "cayman-981-981-2013-2016",
+    "title": "Cayman (981) — 2013–2016",
     "model_family": "Cayman",
     "generation": "981",
-    "variants": [
+    "variant": "981",
+    "years": "2013–2016",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "cayman-981",
+    "model_title": "Cayman (981)",
+    "items": [
       {
-        "name": "981",
-        "heading": "2013–2016",
-        "years": "2013–2016",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£385",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "385"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£545",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "545"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£240",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "240"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "60k miles",
-            "price": "£125",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "125"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£185",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "185"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£385",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "385"
       },
       {
-        "name": "981",
-        "heading": "2013–2016, Manual",
-        "years": "2013–2016",
-        "powertrain": "",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox Oil",
-            "interval": "120k miles",
-            "price": "£95",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£545",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "545"
       },
       {
-        "name": "981",
-        "heading": "2013–2016, PDK",
-        "years": "2013–2016",
-        "powertrain": "",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "120k miles",
-            "price": "£210",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "210"
-          }
-        ]
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£240",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "240"
+      },
+      {
+        "job": "Air Filter",
+        "interval": "60k miles",
+        "price": "£125",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "125"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£185",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "185"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "boxster-718",
-    "title": "Boxster (718)",
+    "id": "cayman-981-981-2013-2016-manual",
+    "title": "Cayman (981) — 2013–2016, Manual",
+    "model_family": "Cayman",
+    "generation": "981",
+    "variant": "981",
+    "years": "2013–2016",
+    "powertrain": "",
+    "transmission": "Manual",
+    "model_slug": "cayman-981",
+    "model_title": "Cayman (981)",
+    "items": [
+      {
+        "job": "Manual Gearbox Oil",
+        "interval": "120k miles",
+        "price": "£95",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "cayman-981-981-2013-2016-pdk",
+    "title": "Cayman (981) — 2013–2016, PDK",
+    "model_family": "Cayman",
+    "generation": "981",
+    "variant": "981",
+    "years": "2013–2016",
+    "powertrain": "",
+    "transmission": "PDK",
+    "model_slug": "cayman-981",
+    "model_title": "Cayman (981)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "120k miles",
+        "price": "£210",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "210"
+      }
+    ]
+  },
+  {
+    "id": "boxster-718-718-2017-2022",
+    "title": "Boxster (718) — 2017–2022",
     "model_family": "Boxster",
     "generation": "718",
-    "variants": [
+    "variant": "718",
+    "years": "2017–2022",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "boxster-718",
+    "model_title": "Boxster (718)",
+    "items": [
       {
-        "name": "718",
-        "heading": "2017–2022",
-        "years": "2017–2022",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£380",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "380"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£550",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "550"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£165",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "165"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£215",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "215"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "60k miles",
-            "price": "£140",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "140"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£140",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "140"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£380",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "380"
       },
       {
-        "name": "718",
-        "heading": "2017–2022, Manual",
-        "years": "2017–2022",
-        "powertrain": "",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox Oil",
-            "interval": "120k miles",
-            "price": "£90",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "90"
-          }
-        ]
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£550",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "550"
       },
       {
-        "name": "718",
-        "heading": "2017–2022, PDK",
-        "years": "2017–2022",
-        "powertrain": "",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "120k miles",
-            "price": "£210",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "210"
-          }
-        ]
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£165",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "165"
+      },
+      {
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£215",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "215"
+      },
+      {
+        "job": "Air Filter",
+        "interval": "60k miles",
+        "price": "£140",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "140"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£140",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "140"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "2",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "boxster-987",
-    "title": "Boxster (987)",
+    "id": "boxster-718-718-2017-2022-manual",
+    "title": "Boxster (718) — 2017–2022, Manual",
+    "model_family": "Boxster",
+    "generation": "718",
+    "variant": "718",
+    "years": "2017–2022",
+    "powertrain": "",
+    "transmission": "Manual",
+    "model_slug": "boxster-718",
+    "model_title": "Boxster (718)",
+    "items": [
+      {
+        "job": "Manual Gearbox Oil",
+        "interval": "120k miles",
+        "price": "£90",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "90"
+      }
+    ]
+  },
+  {
+    "id": "boxster-718-718-2017-2022-pdk",
+    "title": "Boxster (718) — 2017–2022, PDK",
+    "model_family": "Boxster",
+    "generation": "718",
+    "variant": "718",
+    "years": "2017–2022",
+    "powertrain": "",
+    "transmission": "PDK",
+    "model_slug": "boxster-718",
+    "model_title": "Boxster (718)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "120k miles",
+        "price": "£210",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "210"
+      }
+    ]
+  },
+  {
+    "id": "boxster-987-987-gen-2-2009-2012",
+    "title": "Boxster (987) — Gen 2 (2009–2012)",
     "model_family": "Boxster",
     "generation": "987",
-    "variants": [
+    "variant": "987 Gen 2",
+    "years": "2009–2012",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "boxster-987",
+    "model_title": "Boxster (987)",
+    "items": [
       {
-        "name": "987 Gen 2",
-        "heading": "Gen 2 (2009–2012)",
-        "years": "2009–2012",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£335",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "335"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£505",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "505"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£200",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "200"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£130",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "130"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£335",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "335"
       },
       {
-        "name": "987 Gen 2",
-        "heading": "Gen 2 (2009–2012, Manual)",
-        "years": "2009–2012",
-        "powertrain": "",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox Oil",
-            "interval": "120k miles",
-            "price": "£90",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "90"
-          }
-        ]
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£505",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "505"
       },
       {
-        "name": "987 Gen 2",
-        "heading": "Gen 2 (2009–2012, PDK)",
-        "years": "2009–2012",
-        "powertrain": "",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "60k miles",
-            "price": "£210",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "210"
-          }
-        ]
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£200",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "200"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£130",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "130"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "boxster-986",
-    "title": "Boxster (986)",
+    "id": "boxster-987-987-gen-2-2009-2012-manual",
+    "title": "Boxster (987) — Gen 2 (2009–2012, Manual)",
+    "model_family": "Boxster",
+    "generation": "987",
+    "variant": "987 Gen 2",
+    "years": "2009–2012",
+    "powertrain": "",
+    "transmission": "Manual",
+    "model_slug": "boxster-987",
+    "model_title": "Boxster (987)",
+    "items": [
+      {
+        "job": "Manual Gearbox Oil",
+        "interval": "120k miles",
+        "price": "£90",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "90"
+      }
+    ]
+  },
+  {
+    "id": "boxster-987-987-gen-2-2009-2012-pdk",
+    "title": "Boxster (987) — Gen 2 (2009–2012, PDK)",
+    "model_family": "Boxster",
+    "generation": "987",
+    "variant": "987 Gen 2",
+    "years": "2009–2012",
+    "powertrain": "",
+    "transmission": "PDK",
+    "model_slug": "boxster-987",
+    "model_title": "Boxster (987)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "60k miles",
+        "price": "£210",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "210"
+      }
+    ]
+  },
+  {
+    "id": "boxster-986-986-1998-2004",
+    "title": "Boxster (986) — 1998–2004",
     "model_family": "Boxster",
     "generation": "986",
-    "variants": [
+    "variant": "986",
+    "years": "1998–2004",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "boxster-986",
+    "model_title": "Boxster (986)",
+    "items": [
       {
-        "name": "986",
-        "heading": "1998–2004",
-        "years": "1998–2004",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Maintenance",
-            "interval": "1 year",
-            "price": "£105",
-            "service_category": "Scheduled Service",
-            "service_item": "Maintenance",
-            "interval_miles": "",
-            "interval_years": "1",
-            "raw_price": "105"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "20k miles / 12 years",
-            "price": "£270",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "12",
-            "raw_price": "270"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles / 24 years",
-            "price": "£470",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "24",
-            "raw_price": "470"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles / 48 years",
-            "price": "£165",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "48",
-            "raw_price": "165"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles / 48 years",
-            "price": "£125",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "48",
-            "raw_price": "125"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Maintenance",
+        "interval": "1 year",
+        "price": "£105",
+        "service_category": "Scheduled Service",
+        "service_item": "Maintenance",
+        "interval_miles": "",
+        "interval_years": "1",
+        "raw_price": "105"
+      },
+      {
+        "job": "Minor Service",
+        "interval": "20k miles / 12 years",
+        "price": "£270",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "12",
+        "raw_price": "270"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles / 24 years",
+        "price": "£470",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "24",
+        "raw_price": "470"
+      },
+      {
+        "job": "Spark Plugs",
+        "interval": "40k miles / 48 years",
+        "price": "£165",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "48",
+        "raw_price": "165"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "60k miles / 48 years",
+        "price": "£125",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "48",
+        "raw_price": "125"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "boxster-981",
-    "title": "Boxster (981)",
+    "id": "boxster-981-981-2013-2016",
+    "title": "Boxster (981) — 2013–2016",
     "model_family": "Boxster",
     "generation": "981",
-    "variants": [
+    "variant": "981",
+    "years": "2013–2016",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "boxster-981",
+    "model_title": "Boxster (981)",
+    "items": [
       {
-        "name": "981",
-        "heading": "2013–2016",
-        "years": "2013–2016",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£385",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "385"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£545",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "545"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "20k miles",
-            "price": "£240",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "240"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "60k miles",
-            "price": "£125",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "125"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£185",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "185"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£385",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "385"
       },
       {
-        "name": "981",
-        "heading": "2013–2016, Manual",
-        "years": "2013–2016",
-        "powertrain": "",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox Oil",
-            "interval": "120k miles",
-            "price": "£95",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£545",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "545"
       },
       {
-        "name": "981",
-        "heading": "2013–2016, PDK",
-        "years": "2013–2016",
-        "powertrain": "",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "120k miles",
-            "price": "£210",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "210"
-          }
-        ]
+        "job": "Spark Plugs",
+        "interval": "20k miles",
+        "price": "£240",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "240"
+      },
+      {
+        "job": "Air Filter",
+        "interval": "60k miles",
+        "price": "£125",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "125"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£185",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "185"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "2",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "911-992",
-    "title": "911 (992)",
+    "id": "boxster-981-981-2013-2016-manual",
+    "title": "Boxster (981) — 2013–2016, Manual",
+    "model_family": "Boxster",
+    "generation": "981",
+    "variant": "981",
+    "years": "2013–2016",
+    "powertrain": "",
+    "transmission": "Manual",
+    "model_slug": "boxster-981",
+    "model_title": "Boxster (981)",
+    "items": [
+      {
+        "job": "Manual Gearbox Oil",
+        "interval": "120k miles",
+        "price": "£95",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "boxster-981-981-2013-2016-pdk",
+    "title": "Boxster (981) — 2013–2016, PDK",
+    "model_family": "Boxster",
+    "generation": "981",
+    "variant": "981",
+    "years": "2013–2016",
+    "powertrain": "",
+    "transmission": "PDK",
+    "model_slug": "boxster-981",
+    "model_title": "Boxster (981)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "120k miles",
+        "price": "£210",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "210"
+      }
+    ]
+  },
+  {
+    "id": "911-992-992-carrera-carrera-s-2019-2022",
+    "title": "911 (992) — Carrera / Carrera S (2019–2022)",
     "model_family": "911",
     "generation": "992",
-    "variants": [
+    "variant": "992 Carrera / Carrera S",
+    "years": "2019–2022",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "911-992",
+    "model_title": "911 (992)",
+    "items": [
       {
-        "name": "992 Carrera / Carrera S",
-        "heading": "Carrera / Carrera S (2019–2022)",
-        "years": "2019–2022",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£415",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "415"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£635",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "635"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£235",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "235"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "60k miles",
-            "price": "£305",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "305"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£255",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "255"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£415",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "415"
       },
       {
-        "name": "992 Carrera / Carrera S",
-        "heading": "Carrera / Carrera S (2019–2022, Manual)",
-        "years": "2019–2022",
-        "powertrain": "",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox/Diff",
-            "interval": "120k miles",
-            "price": "£120",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox/Diff",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "120"
-          }
-        ]
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£635",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "635"
       },
       {
-        "name": "992 Carrera / Carrera S",
-        "heading": "Carrera / Carrera S (2019–2022, PDK)",
-        "years": "2019–2022",
-        "powertrain": "",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "120k miles",
-            "price": "£205",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "205"
-          }
-        ]
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£235",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "235"
       },
       {
-        "name": "992 Carrera 4 / 4S",
-        "heading": "Carrera 4 / 4S (2019–2022)",
-        "years": "2019–2022",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£415",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "415"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£635",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "635"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£235",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "235"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "60k miles",
-            "price": "£305",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "305"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£255",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "255"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Air Filter",
+        "interval": "60k miles",
+        "price": "£305",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "305"
       },
       {
-        "name": "992 Carrera 4 / 4S",
-        "heading": "Carrera 4 / 4S (2019–2022, Manual)",
-        "years": "2019–2022",
-        "powertrain": "",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox/Diff",
-            "interval": "120k miles",
-            "price": "£120",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox/Diff",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "120"
-          }
-        ]
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£255",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "255"
       },
       {
-        "name": "992 Carrera 4 / 4S",
-        "heading": "Carrera 4 / 4S (2019–2022, PDK)",
-        "years": "2019–2022",
-        "powertrain": "",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "120k miles",
-            "price": "£205",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "205"
-          }
-        ]
-      },
-      {
-        "name": "992 Turbo / Turbo S",
-        "heading": "Turbo / Turbo S (2020–2022, Petrol (Turbo S))",
-        "years": "2020–2022",
-        "powertrain": "Petrol (Turbo S)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£435",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "435"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£640",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "640"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£445",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "445"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "60k miles",
-            "price": "£315",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "315"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£255",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "255"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
-      },
-      {
-        "name": "992 Turbo / Turbo S",
-        "heading": "Turbo / Turbo S (2020–2022, Petrol (Turbo S), Manual)",
-        "years": "2020–2022",
-        "powertrain": "Petrol (Turbo S)",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox/Diff",
-            "interval": "120k miles",
-            "price": "£120",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox/Diff",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "120"
-          }
-        ]
-      },
-      {
-        "name": "992 Turbo / Turbo S",
-        "heading": "Turbo / Turbo S (2020–2022, Petrol (Turbo S), PDK)",
-        "years": "2020–2022",
-        "powertrain": "Petrol (Turbo S)",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "120k miles",
-            "price": "£205",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "205"
-          }
-        ]
-      },
-      {
-        "name": "992 GT3 / GT3 RS",
-        "heading": "GT3 / GT3 RS (2021–2022, Petrol (GT))",
-        "years": "2021–2022",
-        "powertrain": "Petrol (GT)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£455",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "455"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£655",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "655"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£215",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "215"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "60k miles",
-            "price": "£610",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "610"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£265",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "265"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
-      },
-      {
-        "name": "992 GT3 / GT3 RS",
-        "heading": "GT3 / GT3 RS (2021–2022, Petrol (GT), Manual)",
-        "years": "2021–2022",
-        "powertrain": "Petrol (GT)",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox/Diff",
-            "interval": "120k miles",
-            "price": "£120",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox/Diff",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "120"
-          }
-        ]
-      },
-      {
-        "name": "992 GT3 / GT3 RS",
-        "heading": "GT3 / GT3 RS (2021–2022, Petrol (GT), PDK)",
-        "years": "2021–2022",
-        "powertrain": "Petrol (GT)",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "120k miles",
-            "price": "£205",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "205"
-          }
-        ]
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "911-991",
-    "title": "911 (991)",
+    "id": "911-992-992-carrera-carrera-s-2019-2022-manual",
+    "title": "911 (992) — Carrera / Carrera S (2019–2022, Manual)",
+    "model_family": "911",
+    "generation": "992",
+    "variant": "992 Carrera / Carrera S",
+    "years": "2019–2022",
+    "powertrain": "",
+    "transmission": "Manual",
+    "model_slug": "911-992",
+    "model_title": "911 (992)",
+    "items": [
+      {
+        "job": "Manual Gearbox/Diff",
+        "interval": "120k miles",
+        "price": "£120",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox/Diff",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "120"
+      }
+    ]
+  },
+  {
+    "id": "911-992-992-carrera-carrera-s-2019-2022-pdk",
+    "title": "911 (992) — Carrera / Carrera S (2019–2022, PDK)",
+    "model_family": "911",
+    "generation": "992",
+    "variant": "992 Carrera / Carrera S",
+    "years": "2019–2022",
+    "powertrain": "",
+    "transmission": "PDK",
+    "model_slug": "911-992",
+    "model_title": "911 (992)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "120k miles",
+        "price": "£205",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "205"
+      }
+    ]
+  },
+  {
+    "id": "911-992-992-carrera-4-4s-2019-2022",
+    "title": "911 (992) — Carrera 4 / 4S (2019–2022)",
+    "model_family": "911",
+    "generation": "992",
+    "variant": "992 Carrera 4 / 4S",
+    "years": "2019–2022",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "911-992",
+    "model_title": "911 (992)",
+    "items": [
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£415",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "415"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£635",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "635"
+      },
+      {
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£235",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "235"
+      },
+      {
+        "job": "Air Filter",
+        "interval": "60k miles",
+        "price": "£305",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "305"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£255",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "255"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "911-992-992-carrera-4-4s-2019-2022-manual",
+    "title": "911 (992) — Carrera 4 / 4S (2019–2022, Manual)",
+    "model_family": "911",
+    "generation": "992",
+    "variant": "992 Carrera 4 / 4S",
+    "years": "2019–2022",
+    "powertrain": "",
+    "transmission": "Manual",
+    "model_slug": "911-992",
+    "model_title": "911 (992)",
+    "items": [
+      {
+        "job": "Manual Gearbox/Diff",
+        "interval": "120k miles",
+        "price": "£120",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox/Diff",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "120"
+      }
+    ]
+  },
+  {
+    "id": "911-992-992-carrera-4-4s-2019-2022-pdk",
+    "title": "911 (992) — Carrera 4 / 4S (2019–2022, PDK)",
+    "model_family": "911",
+    "generation": "992",
+    "variant": "992 Carrera 4 / 4S",
+    "years": "2019–2022",
+    "powertrain": "",
+    "transmission": "PDK",
+    "model_slug": "911-992",
+    "model_title": "911 (992)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "120k miles",
+        "price": "£205",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "205"
+      }
+    ]
+  },
+  {
+    "id": "911-992-992-turbo-turbo-s-2020-2022-petrol-turbo-s",
+    "title": "911 (992) — Turbo / Turbo S (2020–2022, Petrol (Turbo S))",
+    "model_family": "911",
+    "generation": "992",
+    "variant": "992 Turbo / Turbo S",
+    "years": "2020–2022",
+    "powertrain": "Petrol (Turbo S)",
+    "transmission": "",
+    "model_slug": "911-992",
+    "model_title": "911 (992)",
+    "items": [
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£435",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "435"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£640",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "640"
+      },
+      {
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£445",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "445"
+      },
+      {
+        "job": "Air Filter",
+        "interval": "60k miles",
+        "price": "£315",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "315"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£255",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "255"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "911-992-992-turbo-turbo-s-2020-2022-petrol-turbo-s-manual",
+    "title": "911 (992) — Turbo / Turbo S (2020–2022, Petrol (Turbo S), Manual)",
+    "model_family": "911",
+    "generation": "992",
+    "variant": "992 Turbo / Turbo S",
+    "years": "2020–2022",
+    "powertrain": "Petrol (Turbo S)",
+    "transmission": "Manual",
+    "model_slug": "911-992",
+    "model_title": "911 (992)",
+    "items": [
+      {
+        "job": "Manual Gearbox/Diff",
+        "interval": "120k miles",
+        "price": "£120",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox/Diff",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "120"
+      }
+    ]
+  },
+  {
+    "id": "911-992-992-turbo-turbo-s-2020-2022-petrol-turbo-s-pdk",
+    "title": "911 (992) — Turbo / Turbo S (2020–2022, Petrol (Turbo S), PDK)",
+    "model_family": "911",
+    "generation": "992",
+    "variant": "992 Turbo / Turbo S",
+    "years": "2020–2022",
+    "powertrain": "Petrol (Turbo S)",
+    "transmission": "PDK",
+    "model_slug": "911-992",
+    "model_title": "911 (992)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "120k miles",
+        "price": "£205",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "205"
+      }
+    ]
+  },
+  {
+    "id": "911-992-992-gt3-gt3-rs-2021-2022-petrol-gt",
+    "title": "911 (992) — GT3 / GT3 RS (2021–2022, Petrol (GT))",
+    "model_family": "911",
+    "generation": "992",
+    "variant": "992 GT3 / GT3 RS",
+    "years": "2021–2022",
+    "powertrain": "Petrol (GT)",
+    "transmission": "",
+    "model_slug": "911-992",
+    "model_title": "911 (992)",
+    "items": [
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£455",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "455"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£655",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "655"
+      },
+      {
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£215",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "215"
+      },
+      {
+        "job": "Air Filter",
+        "interval": "60k miles",
+        "price": "£610",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "610"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£265",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "265"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "911-992-992-gt3-gt3-rs-2021-2022-petrol-gt-manual",
+    "title": "911 (992) — GT3 / GT3 RS (2021–2022, Petrol (GT), Manual)",
+    "model_family": "911",
+    "generation": "992",
+    "variant": "992 GT3 / GT3 RS",
+    "years": "2021–2022",
+    "powertrain": "Petrol (GT)",
+    "transmission": "Manual",
+    "model_slug": "911-992",
+    "model_title": "911 (992)",
+    "items": [
+      {
+        "job": "Manual Gearbox/Diff",
+        "interval": "120k miles",
+        "price": "£120",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox/Diff",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "120"
+      }
+    ]
+  },
+  {
+    "id": "911-992-992-gt3-gt3-rs-2021-2022-petrol-gt-pdk",
+    "title": "911 (992) — GT3 / GT3 RS (2021–2022, Petrol (GT), PDK)",
+    "model_family": "911",
+    "generation": "992",
+    "variant": "992 GT3 / GT3 RS",
+    "years": "2021–2022",
+    "powertrain": "Petrol (GT)",
+    "transmission": "PDK",
+    "model_slug": "911-992",
+    "model_title": "911 (992)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "120k miles",
+        "price": "£205",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "205"
+      }
+    ]
+  },
+  {
+    "id": "911-991-991-gen-1-2011-2016",
+    "title": "911 (991) — Gen 1 (2011–2016)",
     "model_family": "911",
     "generation": "991",
-    "variants": [
+    "variant": "991 Gen 1",
+    "years": "2011–2016",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "911-991",
+    "model_title": "911 (991)",
+    "items": [
       {
-        "name": "991 Gen 1",
-        "heading": "Gen 1 (2011–2016)",
-        "years": "2011–2016",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£400",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "400"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£570",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "570"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£190",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "190"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "60k miles",
-            "price": "£270",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "270"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£255",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "255"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£400",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "400"
       },
       {
-        "name": "991 Gen 1",
-        "heading": "Gen 1 (2011–2016, Manual)",
-        "years": "2011–2016",
-        "powertrain": "",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox/Diff",
-            "interval": "120k miles",
-            "price": "£120",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox/Diff",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "120"
-          }
-        ]
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£570",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "570"
       },
       {
-        "name": "991 Gen 1",
-        "heading": "Gen 1 (2011–2016, PDK)",
-        "years": "2011–2016",
-        "powertrain": "",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "120k miles",
-            "price": "£205",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "205"
-          }
-        ]
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£190",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "190"
       },
       {
-        "name": "991 GT3 / RS Gen 1",
-        "heading": "GT3 / RS Gen 1 (Petrol (GT))",
-        "years": "",
-        "powertrain": "Petrol (GT)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£410",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "410"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£705",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "705"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£340",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "340"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "40k miles",
-            "price": "£230",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "230"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "40k miles",
-            "price": "£640",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "640"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "40k miles",
-            "price": "£265",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "265"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Air Filter",
+        "interval": "60k miles",
+        "price": "£270",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "270"
       },
       {
-        "name": "991 GT3 / RS Gen 1",
-        "heading": "GT3 / RS Gen 1 (Petrol (GT), Manual)",
-        "years": "",
-        "powertrain": "Petrol (GT)",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox/Diff",
-            "interval": "120k miles",
-            "price": "£120",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox/Diff",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "120"
-          }
-        ]
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£255",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "255"
       },
       {
-        "name": "991 GT3 / RS Gen 1",
-        "heading": "GT3 / RS Gen 1 (Petrol (GT), PDK)",
-        "years": "",
-        "powertrain": "Petrol (GT)",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "60k miles",
-            "price": "£205",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "205"
-          }
-        ]
-      },
-      {
-        "name": "991 Turbo Gen 1 & 2",
-        "heading": "Turbo Gen 1 & 2 (Petrol (Turbo))",
-        "years": "",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£400",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "400"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£615",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "615"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£435",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "435"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "40k miles",
-            "price": "£475",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "475"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£365",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "365"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
-      },
-      {
-        "name": "991 Turbo Gen 1 & 2",
-        "heading": "Turbo Gen 1 & 2 (Petrol (Turbo), Manual)",
-        "years": "",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox/Diff",
-            "interval": "120k miles",
-            "price": "£120",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox/Diff",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "120"
-          }
-        ]
-      },
-      {
-        "name": "991 Turbo Gen 1 & 2",
-        "heading": "Turbo Gen 1 & 2 (Petrol (Turbo), PDK)",
-        "years": "",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "120k miles",
-            "price": "£205",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "205"
-          }
-        ]
-      },
-      {
-        "name": "991 Gen 2",
-        "heading": "Gen 2 (2016–2019)",
-        "years": "2016–2019",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£400",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "400"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£570",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "570"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£190",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "190"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "60k miles",
-            "price": "£295",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "295"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£255",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "255"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
-      },
-      {
-        "name": "991 Gen 2",
-        "heading": "Gen 2 (2016–2019, Manual)",
-        "years": "2016–2019",
-        "powertrain": "",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox/Diff",
-            "interval": "120k miles",
-            "price": "£120",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox/Diff",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "120"
-          }
-        ]
-      },
-      {
-        "name": "991 Gen 2",
-        "heading": "Gen 2 (2016–2019, PDK)",
-        "years": "2016–2019",
-        "powertrain": "",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "120k miles",
-            "price": "£205",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "205"
-          }
-        ]
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "911-997",
-    "title": "911 (997)",
+    "id": "911-991-991-gen-1-2011-2016-manual",
+    "title": "911 (991) — Gen 1 (2011–2016, Manual)",
+    "model_family": "911",
+    "generation": "991",
+    "variant": "991 Gen 1",
+    "years": "2011–2016",
+    "powertrain": "",
+    "transmission": "Manual",
+    "model_slug": "911-991",
+    "model_title": "911 (991)",
+    "items": [
+      {
+        "job": "Manual Gearbox/Diff",
+        "interval": "120k miles",
+        "price": "£120",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox/Diff",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "120"
+      }
+    ]
+  },
+  {
+    "id": "911-991-991-gen-1-2011-2016-pdk",
+    "title": "911 (991) — Gen 1 (2011–2016, PDK)",
+    "model_family": "911",
+    "generation": "991",
+    "variant": "991 Gen 1",
+    "years": "2011–2016",
+    "powertrain": "",
+    "transmission": "PDK",
+    "model_slug": "911-991",
+    "model_title": "911 (991)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "120k miles",
+        "price": "£205",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "205"
+      }
+    ]
+  },
+  {
+    "id": "911-991-991-gt3-rs-gen-1-petrol-gt",
+    "title": "911 (991) — GT3 / RS Gen 1 (Petrol (GT))",
+    "model_family": "911",
+    "generation": "991",
+    "variant": "991 GT3 / RS Gen 1",
+    "years": "",
+    "powertrain": "Petrol (GT)",
+    "transmission": "",
+    "model_slug": "911-991",
+    "model_title": "911 (991)",
+    "items": [
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£410",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "410"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£705",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "705"
+      },
+      {
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£340",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "340"
+      },
+      {
+        "job": "Air Filter",
+        "interval": "40k miles",
+        "price": "£230",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "230"
+      },
+      {
+        "job": "Air Filter",
+        "interval": "40k miles",
+        "price": "£640",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "640"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "40k miles",
+        "price": "£265",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "265"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "911-991-991-gt3-rs-gen-1-petrol-gt-manual",
+    "title": "911 (991) — GT3 / RS Gen 1 (Petrol (GT), Manual)",
+    "model_family": "911",
+    "generation": "991",
+    "variant": "991 GT3 / RS Gen 1",
+    "years": "",
+    "powertrain": "Petrol (GT)",
+    "transmission": "Manual",
+    "model_slug": "911-991",
+    "model_title": "911 (991)",
+    "items": [
+      {
+        "job": "Manual Gearbox/Diff",
+        "interval": "120k miles",
+        "price": "£120",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox/Diff",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "120"
+      }
+    ]
+  },
+  {
+    "id": "911-991-991-gt3-rs-gen-1-petrol-gt-pdk",
+    "title": "911 (991) — GT3 / RS Gen 1 (Petrol (GT), PDK)",
+    "model_family": "911",
+    "generation": "991",
+    "variant": "991 GT3 / RS Gen 1",
+    "years": "",
+    "powertrain": "Petrol (GT)",
+    "transmission": "PDK",
+    "model_slug": "911-991",
+    "model_title": "911 (991)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "60k miles",
+        "price": "£205",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "205"
+      }
+    ]
+  },
+  {
+    "id": "911-991-991-turbo-gen-1-2-petrol-turbo",
+    "title": "911 (991) — Turbo Gen 1 & 2 (Petrol (Turbo))",
+    "model_family": "911",
+    "generation": "991",
+    "variant": "991 Turbo Gen 1 & 2",
+    "years": "",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "",
+    "model_slug": "911-991",
+    "model_title": "911 (991)",
+    "items": [
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£400",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "400"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£615",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "615"
+      },
+      {
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£435",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "435"
+      },
+      {
+        "job": "Air Filter",
+        "interval": "40k miles",
+        "price": "£475",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "475"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£365",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "365"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "2",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "911-991-991-turbo-gen-1-2-petrol-turbo-manual",
+    "title": "911 (991) — Turbo Gen 1 & 2 (Petrol (Turbo), Manual)",
+    "model_family": "911",
+    "generation": "991",
+    "variant": "991 Turbo Gen 1 & 2",
+    "years": "",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "Manual",
+    "model_slug": "911-991",
+    "model_title": "911 (991)",
+    "items": [
+      {
+        "job": "Manual Gearbox/Diff",
+        "interval": "120k miles",
+        "price": "£120",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox/Diff",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "120"
+      }
+    ]
+  },
+  {
+    "id": "911-991-991-turbo-gen-1-2-petrol-turbo-pdk",
+    "title": "911 (991) — Turbo Gen 1 & 2 (Petrol (Turbo), PDK)",
+    "model_family": "911",
+    "generation": "991",
+    "variant": "991 Turbo Gen 1 & 2",
+    "years": "",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "PDK",
+    "model_slug": "911-991",
+    "model_title": "911 (991)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "120k miles",
+        "price": "£205",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "205"
+      }
+    ]
+  },
+  {
+    "id": "911-991-991-gen-2-2016-2019",
+    "title": "911 (991) — Gen 2 (2016–2019)",
+    "model_family": "911",
+    "generation": "991",
+    "variant": "991 Gen 2",
+    "years": "2016–2019",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "911-991",
+    "model_title": "911 (991)",
+    "items": [
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£400",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "400"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£570",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "570"
+      },
+      {
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£190",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "190"
+      },
+      {
+        "job": "Air Filter",
+        "interval": "60k miles",
+        "price": "£295",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "295"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£255",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "255"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "911-991-991-gen-2-2016-2019-manual",
+    "title": "911 (991) — Gen 2 (2016–2019, Manual)",
+    "model_family": "911",
+    "generation": "991",
+    "variant": "991 Gen 2",
+    "years": "2016–2019",
+    "powertrain": "",
+    "transmission": "Manual",
+    "model_slug": "911-991",
+    "model_title": "911 (991)",
+    "items": [
+      {
+        "job": "Manual Gearbox/Diff",
+        "interval": "120k miles",
+        "price": "£120",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox/Diff",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "120"
+      }
+    ]
+  },
+  {
+    "id": "911-991-991-gen-2-2016-2019-pdk",
+    "title": "911 (991) — Gen 2 (2016–2019, PDK)",
+    "model_family": "911",
+    "generation": "991",
+    "variant": "991 Gen 2",
+    "years": "2016–2019",
+    "powertrain": "",
+    "transmission": "PDK",
+    "model_slug": "911-991",
+    "model_title": "911 (991)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "120k miles",
+        "price": "£205",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "205"
+      }
+    ]
+  },
+  {
+    "id": "911-997-997-gen-1-2004-2008",
+    "title": "911 (997) — Gen 1 (2004–2008)",
     "model_family": "911",
     "generation": "997",
-    "variants": [
+    "variant": "997 Gen 1",
+    "years": "2004–2008",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "911-997",
+    "model_title": "911 (997)",
+    "items": [
       {
-        "name": "997 Gen 1",
-        "heading": "Gen 1 (2004–2008)",
-        "years": "2004–2008",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£345",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "345"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£515",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "515"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£190",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "190"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "40k miles",
-            "price": "£65",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "65"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£135",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "135"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£345",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "345"
       },
       {
-        "name": "997 Gen 1",
-        "heading": "Gen 1 (2004–2008, Manual)",
-        "years": "2004–2008",
-        "powertrain": "",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox Oil",
-            "interval": "120k miles",
-            "price": "£90",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "90"
-          }
-        ]
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£515",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "515"
       },
       {
-        "name": "997 Gen 1",
-        "heading": "Gen 1 (2004–2008, Tiptronic)",
-        "years": "2004–2008",
-        "powertrain": "",
-        "transmission": "Tiptronic",
-        "items": [
-          {
-            "job": "Tiptronic Gearbox Oil",
-            "interval": "120k miles",
-            "price": "£300",
-            "service_category": "Transmission",
-            "service_item": "Tiptronic Gearbox Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "300"
-          }
-        ]
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£190",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "190"
       },
       {
-        "name": "997 Gen 2",
-        "heading": "Gen 2 (2008–2012)",
-        "years": "2008–2012",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£345",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "345"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£515",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "515"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£310",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "310"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "40k miles",
-            "price": "£120",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "120"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£135",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "135"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Air Filter",
+        "interval": "40k miles",
+        "price": "£65",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "65"
       },
       {
-        "name": "997 Gen 2",
-        "heading": "Gen 2 (2008–2012, Manual)",
-        "years": "2008–2012",
-        "powertrain": "",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox Oil",
-            "interval": "120k miles",
-            "price": "£90",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "90"
-          }
-        ]
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£135",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "135"
       },
       {
-        "name": "997 Gen 2",
-        "heading": "Gen 2 (2008–2012, PDK)",
-        "years": "2008–2012",
-        "powertrain": "",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "60k miles",
-            "price": "£215",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "215"
-          }
-        ]
-      },
-      {
-        "name": "997 GT3 / RS",
-        "heading": "GT3 / RS (2009–2012, Petrol (GT))",
-        "years": "2009–2012",
-        "powertrain": "Petrol (GT)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£380",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "380"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£575",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "575"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£395",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "395"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "40k miles",
-            "price": "£140",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "140"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£150",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "150"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
-      },
-      {
-        "name": "997 GT3 / RS",
-        "heading": "GT3 / RS (2009–2012, Petrol (GT), Manual)",
-        "years": "2009–2012",
-        "powertrain": "Petrol (GT)",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox Oil",
-            "interval": "120k miles",
-            "price": "£90",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "90"
-          }
-        ]
-      },
-      {
-        "name": "997 Turbo / GT2 Gen 1",
-        "heading": "Turbo / GT2 Gen 1 (2005–2008, Petrol (Turbo))",
-        "years": "2005–2008",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£360",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "360"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£575",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "575"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£395",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "395"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "40k miles",
-            "price": "£120",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "120"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£150",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "150"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
-      },
-      {
-        "name": "997 Turbo / GT2 Gen 1",
-        "heading": "Turbo / GT2 Gen 1 (2005–2008, Petrol (Turbo), Manual)",
-        "years": "2005–2008",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox Oil",
-            "interval": "120k miles",
-            "price": "£90",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "90"
-          }
-        ]
-      },
-      {
-        "name": "997 Turbo / GT2 Gen 1",
-        "heading": "Turbo / GT2 Gen 1 (2005–2008, Petrol (Turbo), Tiptronic)",
-        "years": "2005–2008",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "Tiptronic",
-        "items": [
-          {
-            "job": "Tiptronic Gearbox Oil",
-            "interval": "120k miles",
-            "price": "£300",
-            "service_category": "Transmission",
-            "service_item": "Tiptronic Gearbox Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "300"
-          }
-        ]
-      },
-      {
-        "name": "997 Turbo / GT2 Gen 2",
-        "heading": "Turbo / GT2 Gen 2 (2010–2012, Petrol (Turbo))",
-        "years": "2010–2012",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "20k miles",
-            "price": "£370",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "20000",
-            "interval_years": "",
-            "raw_price": "370"
-          },
-          {
-            "job": "Major Service",
-            "interval": "40k miles",
-            "price": "£575",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "575"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "40k miles",
-            "price": "£395",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "395"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "40k miles",
-            "price": "£130",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "40000",
-            "interval_years": "",
-            "raw_price": "130"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "60k miles",
-            "price": "£150",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "150"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
-      },
-      {
-        "name": "997 Turbo / GT2 Gen 2",
-        "heading": "Turbo / GT2 Gen 2 (2010–2012, Petrol (Turbo), Manual)",
-        "years": "2010–2012",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox Oil",
-            "interval": "120k miles",
-            "price": "£90",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox Oil",
-            "interval_miles": "120000",
-            "interval_years": "",
-            "raw_price": "90"
-          }
-        ]
-      },
-      {
-        "name": "997 Turbo / GT2 Gen 2",
-        "heading": "Turbo / GT2 Gen 2 (2010–2012, Petrol (Turbo), PDK)",
-        "years": "2010–2012",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "PDK",
-        "items": [
-          {
-            "job": "PDK Oil",
-            "interval": "60k miles",
-            "price": "£215",
-            "service_category": "Transmission",
-            "service_item": "PDK Oil",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "215"
-          }
-        ]
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "911-996",
-    "title": "911 (996)",
+    "id": "911-997-997-gen-1-2004-2008-manual",
+    "title": "911 (997) — Gen 1 (2004–2008, Manual)",
+    "model_family": "911",
+    "generation": "997",
+    "variant": "997 Gen 1",
+    "years": "2004–2008",
+    "powertrain": "",
+    "transmission": "Manual",
+    "model_slug": "911-997",
+    "model_title": "911 (997)",
+    "items": [
+      {
+        "job": "Manual Gearbox Oil",
+        "interval": "120k miles",
+        "price": "£90",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "90"
+      }
+    ]
+  },
+  {
+    "id": "911-997-997-gen-1-2004-2008-tiptronic",
+    "title": "911 (997) — Gen 1 (2004–2008, Tiptronic)",
+    "model_family": "911",
+    "generation": "997",
+    "variant": "997 Gen 1",
+    "years": "2004–2008",
+    "powertrain": "",
+    "transmission": "Tiptronic",
+    "model_slug": "911-997",
+    "model_title": "911 (997)",
+    "items": [
+      {
+        "job": "Tiptronic Gearbox Oil",
+        "interval": "120k miles",
+        "price": "£300",
+        "service_category": "Transmission",
+        "service_item": "Tiptronic Gearbox Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "300"
+      }
+    ]
+  },
+  {
+    "id": "911-997-997-gen-2-2008-2012",
+    "title": "911 (997) — Gen 2 (2008–2012)",
+    "model_family": "911",
+    "generation": "997",
+    "variant": "997 Gen 2",
+    "years": "2008–2012",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "911-997",
+    "model_title": "911 (997)",
+    "items": [
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£345",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "345"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£515",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "515"
+      },
+      {
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£310",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "310"
+      },
+      {
+        "job": "Air Filter",
+        "interval": "40k miles",
+        "price": "£120",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "120"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£135",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "135"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "911-997-997-gen-2-2008-2012-manual",
+    "title": "911 (997) — Gen 2 (2008–2012, Manual)",
+    "model_family": "911",
+    "generation": "997",
+    "variant": "997 Gen 2",
+    "years": "2008–2012",
+    "powertrain": "",
+    "transmission": "Manual",
+    "model_slug": "911-997",
+    "model_title": "911 (997)",
+    "items": [
+      {
+        "job": "Manual Gearbox Oil",
+        "interval": "120k miles",
+        "price": "£90",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "90"
+      }
+    ]
+  },
+  {
+    "id": "911-997-997-gen-2-2008-2012-pdk",
+    "title": "911 (997) — Gen 2 (2008–2012, PDK)",
+    "model_family": "911",
+    "generation": "997",
+    "variant": "997 Gen 2",
+    "years": "2008–2012",
+    "powertrain": "",
+    "transmission": "PDK",
+    "model_slug": "911-997",
+    "model_title": "911 (997)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "60k miles",
+        "price": "£215",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "215"
+      }
+    ]
+  },
+  {
+    "id": "911-997-997-gt3-rs-2009-2012-petrol-gt",
+    "title": "911 (997) — GT3 / RS (2009–2012, Petrol (GT))",
+    "model_family": "911",
+    "generation": "997",
+    "variant": "997 GT3 / RS",
+    "years": "2009–2012",
+    "powertrain": "Petrol (GT)",
+    "transmission": "",
+    "model_slug": "911-997",
+    "model_title": "911 (997)",
+    "items": [
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£380",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "380"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£575",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "575"
+      },
+      {
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£395",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "395"
+      },
+      {
+        "job": "Air Filter",
+        "interval": "40k miles",
+        "price": "£140",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "140"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£150",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "150"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "911-997-997-gt3-rs-2009-2012-petrol-gt-manual",
+    "title": "911 (997) — GT3 / RS (2009–2012, Petrol (GT), Manual)",
+    "model_family": "911",
+    "generation": "997",
+    "variant": "997 GT3 / RS",
+    "years": "2009–2012",
+    "powertrain": "Petrol (GT)",
+    "transmission": "Manual",
+    "model_slug": "911-997",
+    "model_title": "911 (997)",
+    "items": [
+      {
+        "job": "Manual Gearbox Oil",
+        "interval": "120k miles",
+        "price": "£90",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "90"
+      }
+    ]
+  },
+  {
+    "id": "911-997-997-turbo-gt2-gen-1-2005-2008-petrol-turbo",
+    "title": "911 (997) — Turbo / GT2 Gen 1 (2005–2008, Petrol (Turbo))",
+    "model_family": "911",
+    "generation": "997",
+    "variant": "997 Turbo / GT2 Gen 1",
+    "years": "2005–2008",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "",
+    "model_slug": "911-997",
+    "model_title": "911 (997)",
+    "items": [
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£360",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "360"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£575",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "575"
+      },
+      {
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£395",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "395"
+      },
+      {
+        "job": "Air Filter",
+        "interval": "40k miles",
+        "price": "£120",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "120"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£150",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "150"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "911-997-997-turbo-gt2-gen-1-2005-2008-petrol-turbo-manual",
+    "title": "911 (997) — Turbo / GT2 Gen 1 (2005–2008, Petrol (Turbo), Manual)",
+    "model_family": "911",
+    "generation": "997",
+    "variant": "997 Turbo / GT2 Gen 1",
+    "years": "2005–2008",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "Manual",
+    "model_slug": "911-997",
+    "model_title": "911 (997)",
+    "items": [
+      {
+        "job": "Manual Gearbox Oil",
+        "interval": "120k miles",
+        "price": "£90",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "90"
+      }
+    ]
+  },
+  {
+    "id": "911-997-997-turbo-gt2-gen-1-2005-2008-petrol-turbo-tiptronic",
+    "title": "911 (997) — Turbo / GT2 Gen 1 (2005–2008, Petrol (Turbo), Tiptronic)",
+    "model_family": "911",
+    "generation": "997",
+    "variant": "997 Turbo / GT2 Gen 1",
+    "years": "2005–2008",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "Tiptronic",
+    "model_slug": "911-997",
+    "model_title": "911 (997)",
+    "items": [
+      {
+        "job": "Tiptronic Gearbox Oil",
+        "interval": "120k miles",
+        "price": "£300",
+        "service_category": "Transmission",
+        "service_item": "Tiptronic Gearbox Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "300"
+      }
+    ]
+  },
+  {
+    "id": "911-997-997-turbo-gt2-gen-2-2010-2012-petrol-turbo",
+    "title": "911 (997) — Turbo / GT2 Gen 2 (2010–2012, Petrol (Turbo))",
+    "model_family": "911",
+    "generation": "997",
+    "variant": "997 Turbo / GT2 Gen 2",
+    "years": "2010–2012",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "",
+    "model_slug": "911-997",
+    "model_title": "911 (997)",
+    "items": [
+      {
+        "job": "Minor Service",
+        "interval": "20k miles",
+        "price": "£370",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "20000",
+        "interval_years": "",
+        "raw_price": "370"
+      },
+      {
+        "job": "Major Service",
+        "interval": "40k miles",
+        "price": "£575",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "575"
+      },
+      {
+        "job": "Spark Plugs",
+        "interval": "40k miles",
+        "price": "£395",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "395"
+      },
+      {
+        "job": "Air Filter",
+        "interval": "40k miles",
+        "price": "£130",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "40000",
+        "interval_years": "",
+        "raw_price": "130"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "60k miles",
+        "price": "£150",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "150"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "911-997-997-turbo-gt2-gen-2-2010-2012-petrol-turbo-manual",
+    "title": "911 (997) — Turbo / GT2 Gen 2 (2010–2012, Petrol (Turbo), Manual)",
+    "model_family": "911",
+    "generation": "997",
+    "variant": "997 Turbo / GT2 Gen 2",
+    "years": "2010–2012",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "Manual",
+    "model_slug": "911-997",
+    "model_title": "911 (997)",
+    "items": [
+      {
+        "job": "Manual Gearbox Oil",
+        "interval": "120k miles",
+        "price": "£90",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox Oil",
+        "interval_miles": "120000",
+        "interval_years": "",
+        "raw_price": "90"
+      }
+    ]
+  },
+  {
+    "id": "911-997-997-turbo-gt2-gen-2-2010-2012-petrol-turbo-pdk",
+    "title": "911 (997) — Turbo / GT2 Gen 2 (2010–2012, Petrol (Turbo), PDK)",
+    "model_family": "911",
+    "generation": "997",
+    "variant": "997 Turbo / GT2 Gen 2",
+    "years": "2010–2012",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "PDK",
+    "model_slug": "911-997",
+    "model_title": "911 (997)",
+    "items": [
+      {
+        "job": "PDK Oil",
+        "interval": "60k miles",
+        "price": "£215",
+        "service_category": "Transmission",
+        "service_item": "PDK Oil",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "215"
+      }
+    ]
+  },
+  {
+    "id": "911-996-996-1998-2004",
+    "title": "911 (996) — 1998–2004",
     "model_family": "911",
     "generation": "996",
-    "variants": [
+    "variant": "996",
+    "years": "1998–2004",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "911-996",
+    "model_title": "911 (996)",
+    "items": [
       {
-        "name": "996",
-        "heading": "1998–2004",
-        "years": "1998–2004",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Maintenance",
-            "interval": "1 year",
-            "price": "£105",
-            "service_category": "Scheduled Service",
-            "service_item": "Maintenance",
-            "interval_miles": "",
-            "interval_years": "1",
-            "raw_price": "105"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "12k miles / 12 years",
-            "price": "£275",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "12000",
-            "interval_years": "12",
-            "raw_price": "275"
-          },
-          {
-            "job": "Major Service",
-            "interval": "24k miles / 24 years",
-            "price": "£470",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "24000",
-            "interval_years": "24",
-            "raw_price": "470"
-          },
-          {
-            "job": "Spark Plugs",
-            "interval": "24k miles / 48 years",
-            "price": "£190",
-            "service_category": "Ignition",
-            "service_item": "Spark Plugs",
-            "interval_miles": "24000",
-            "interval_years": "48",
-            "raw_price": "190"
-          },
-          {
-            "job": "Air Filter",
-            "interval": "24k miles / 24 years",
-            "price": "£65",
-            "service_category": "Intake",
-            "service_item": "Air Filter",
-            "interval_miles": "24000",
-            "interval_years": "24",
-            "raw_price": "65"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "48k miles / 48 years",
-            "price": "£135",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "48000",
-            "interval_years": "48",
-            "raw_price": "135"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Maintenance",
+        "interval": "1 year",
+        "price": "£105",
+        "service_category": "Scheduled Service",
+        "service_item": "Maintenance",
+        "interval_miles": "",
+        "interval_years": "1",
+        "raw_price": "105"
       },
       {
-        "name": "996",
-        "heading": "1998–2004, Manual",
-        "years": "1998–2004",
-        "powertrain": "",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox Oil",
-            "interval": "96k miles / 96 years",
-            "price": "£90",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox Oil",
-            "interval_miles": "96000",
-            "interval_years": "96",
-            "raw_price": "90"
-          }
-        ]
+        "job": "Minor Service",
+        "interval": "12k miles / 12 years",
+        "price": "£275",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "12000",
+        "interval_years": "12",
+        "raw_price": "275"
       },
       {
-        "name": "996",
-        "heading": "1998–2004, Tiptronic",
-        "years": "1998–2004",
-        "powertrain": "",
-        "transmission": "Tiptronic",
-        "items": [
-          {
-            "job": "Tiptronic Gearbox Oil",
-            "interval": "96k miles / 96 years",
-            "price": "£305",
-            "service_category": "Transmission",
-            "service_item": "Tiptronic Gearbox Oil",
-            "interval_miles": "96000",
-            "interval_years": "96",
-            "raw_price": "305"
-          }
-        ]
+        "job": "Major Service",
+        "interval": "24k miles / 24 years",
+        "price": "£470",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "24000",
+        "interval_years": "24",
+        "raw_price": "470"
       },
       {
-        "name": "996 GT3",
-        "heading": "GT3 (2001–2004, Petrol (GT))",
-        "years": "2001–2004",
-        "powertrain": "Petrol (GT)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Minor Service",
-            "interval": "12k miles",
-            "price": "£335",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "335"
-          },
-          {
-            "job": "Major Service",
-            "interval": "24k miles",
-            "price": "£780",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "780"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "48k miles",
-            "price": "£185",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "185"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Spark Plugs",
+        "interval": "24k miles / 48 years",
+        "price": "£190",
+        "service_category": "Ignition",
+        "service_item": "Spark Plugs",
+        "interval_miles": "24000",
+        "interval_years": "48",
+        "raw_price": "190"
       },
       {
-        "name": "996 GT3",
-        "heading": "GT3 (2001–2004, Petrol (GT), Manual)",
-        "years": "2001–2004",
-        "powertrain": "Petrol (GT)",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox Oil",
-            "interval": "96k miles",
-            "price": "£90",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox Oil",
-            "interval_miles": "96000",
-            "interval_years": "",
-            "raw_price": "90"
-          }
-        ]
+        "job": "Air Filter",
+        "interval": "24k miles / 24 years",
+        "price": "£65",
+        "service_category": "Intake",
+        "service_item": "Air Filter",
+        "interval_miles": "24000",
+        "interval_years": "24",
+        "raw_price": "65"
       },
       {
-        "name": "996 Turbo / GT2",
-        "heading": "Turbo / GT2 (2001–2004, Petrol (Turbo))",
-        "years": "2001–2004",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Maintenance",
-            "interval": "1 year",
-            "price": "£130",
-            "service_category": "Scheduled Service",
-            "service_item": "Maintenance",
-            "interval_miles": "",
-            "interval_years": "1",
-            "raw_price": "130"
-          },
-          {
-            "job": "Minor Service",
-            "interval": "12k miles",
-            "price": "£325",
-            "service_category": "Scheduled Service",
-            "service_item": "Minor",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "325"
-          },
-          {
-            "job": "Major Service",
-            "interval": "24k miles",
-            "price": "£880",
-            "service_category": "Scheduled Service",
-            "service_item": "Major",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "880"
-          },
-          {
-            "job": "Aux Belt",
-            "interval": "48k miles",
-            "price": "£185",
-            "service_category": "Drive Belt",
-            "service_item": "Aux Belt",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "185"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "20k miles / 2 years",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "20000",
-            "interval_years": "2",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Aux Belt",
+        "interval": "48k miles / 48 years",
+        "price": "£135",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "48000",
+        "interval_years": "48",
+        "raw_price": "135"
       },
       {
-        "name": "996 Turbo / GT2",
-        "heading": "Turbo / GT2 (2001–2004, Petrol (Turbo), Manual)",
-        "years": "2001–2004",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "Manual",
-        "items": [
-          {
-            "job": "Manual Gearbox Oil",
-            "interval": "96k miles",
-            "price": "£90",
-            "service_category": "Transmission",
-            "service_item": "Manual Gearbox Oil",
-            "interval_miles": "96000",
-            "interval_years": "",
-            "raw_price": "90"
-          }
-        ]
-      },
-      {
-        "name": "996 Turbo / GT2",
-        "heading": "Turbo / GT2 (2001–2004, Petrol (Turbo), Tiptronic)",
-        "years": "2001–2004",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "Tiptronic",
-        "items": [
-          {
-            "job": "Tiptronic Gearbox Oil",
-            "interval": "96k miles",
-            "price": "£305",
-            "service_category": "Transmission",
-            "service_item": "Tiptronic Gearbox Oil",
-            "interval_miles": "96000",
-            "interval_years": "",
-            "raw_price": "305"
-          }
-        ]
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "911-964",
-    "title": "911 (964)",
+    "id": "911-996-996-1998-2004-manual",
+    "title": "911 (996) — 1998–2004, Manual",
+    "model_family": "911",
+    "generation": "996",
+    "variant": "996",
+    "years": "1998–2004",
+    "powertrain": "",
+    "transmission": "Manual",
+    "model_slug": "911-996",
+    "model_title": "911 (996)",
+    "items": [
+      {
+        "job": "Manual Gearbox Oil",
+        "interval": "96k miles / 96 years",
+        "price": "£90",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox Oil",
+        "interval_miles": "96000",
+        "interval_years": "96",
+        "raw_price": "90"
+      }
+    ]
+  },
+  {
+    "id": "911-996-996-1998-2004-tiptronic",
+    "title": "911 (996) — 1998–2004, Tiptronic",
+    "model_family": "911",
+    "generation": "996",
+    "variant": "996",
+    "years": "1998–2004",
+    "powertrain": "",
+    "transmission": "Tiptronic",
+    "model_slug": "911-996",
+    "model_title": "911 (996)",
+    "items": [
+      {
+        "job": "Tiptronic Gearbox Oil",
+        "interval": "96k miles / 96 years",
+        "price": "£305",
+        "service_category": "Transmission",
+        "service_item": "Tiptronic Gearbox Oil",
+        "interval_miles": "96000",
+        "interval_years": "96",
+        "raw_price": "305"
+      }
+    ]
+  },
+  {
+    "id": "911-996-996-gt3-2001-2004-petrol-gt",
+    "title": "911 (996) — GT3 (2001–2004, Petrol (GT))",
+    "model_family": "911",
+    "generation": "996",
+    "variant": "996 GT3",
+    "years": "2001–2004",
+    "powertrain": "Petrol (GT)",
+    "transmission": "",
+    "model_slug": "911-996",
+    "model_title": "911 (996)",
+    "items": [
+      {
+        "job": "Minor Service",
+        "interval": "12k miles",
+        "price": "£335",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "335"
+      },
+      {
+        "job": "Major Service",
+        "interval": "24k miles",
+        "price": "£780",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "780"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "48k miles",
+        "price": "£185",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "185"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "911-996-996-gt3-2001-2004-petrol-gt-manual",
+    "title": "911 (996) — GT3 (2001–2004, Petrol (GT), Manual)",
+    "model_family": "911",
+    "generation": "996",
+    "variant": "996 GT3",
+    "years": "2001–2004",
+    "powertrain": "Petrol (GT)",
+    "transmission": "Manual",
+    "model_slug": "911-996",
+    "model_title": "911 (996)",
+    "items": [
+      {
+        "job": "Manual Gearbox Oil",
+        "interval": "96k miles",
+        "price": "£90",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox Oil",
+        "interval_miles": "96000",
+        "interval_years": "",
+        "raw_price": "90"
+      }
+    ]
+  },
+  {
+    "id": "911-996-996-turbo-gt2-2001-2004-petrol-turbo",
+    "title": "911 (996) — Turbo / GT2 (2001–2004, Petrol (Turbo))",
+    "model_family": "911",
+    "generation": "996",
+    "variant": "996 Turbo / GT2",
+    "years": "2001–2004",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "",
+    "model_slug": "911-996",
+    "model_title": "911 (996)",
+    "items": [
+      {
+        "job": "Maintenance",
+        "interval": "1 year",
+        "price": "£130",
+        "service_category": "Scheduled Service",
+        "service_item": "Maintenance",
+        "interval_miles": "",
+        "interval_years": "1",
+        "raw_price": "130"
+      },
+      {
+        "job": "Minor Service",
+        "interval": "12k miles",
+        "price": "£325",
+        "service_category": "Scheduled Service",
+        "service_item": "Minor",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "325"
+      },
+      {
+        "job": "Major Service",
+        "interval": "24k miles",
+        "price": "£880",
+        "service_category": "Scheduled Service",
+        "service_item": "Major",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "880"
+      },
+      {
+        "job": "Aux Belt",
+        "interval": "48k miles",
+        "price": "£185",
+        "service_category": "Drive Belt",
+        "service_item": "Aux Belt",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "185"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "20k miles / 2 years",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "20000",
+        "interval_years": "2",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "911-996-996-turbo-gt2-2001-2004-petrol-turbo-manual",
+    "title": "911 (996) — Turbo / GT2 (2001–2004, Petrol (Turbo), Manual)",
+    "model_family": "911",
+    "generation": "996",
+    "variant": "996 Turbo / GT2",
+    "years": "2001–2004",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "Manual",
+    "model_slug": "911-996",
+    "model_title": "911 (996)",
+    "items": [
+      {
+        "job": "Manual Gearbox Oil",
+        "interval": "96k miles",
+        "price": "£90",
+        "service_category": "Transmission",
+        "service_item": "Manual Gearbox Oil",
+        "interval_miles": "96000",
+        "interval_years": "",
+        "raw_price": "90"
+      }
+    ]
+  },
+  {
+    "id": "911-996-996-turbo-gt2-2001-2004-petrol-turbo-tiptronic",
+    "title": "911 (996) — Turbo / GT2 (2001–2004, Petrol (Turbo), Tiptronic)",
+    "model_family": "911",
+    "generation": "996",
+    "variant": "996 Turbo / GT2",
+    "years": "2001–2004",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "Tiptronic",
+    "model_slug": "911-996",
+    "model_title": "911 (996)",
+    "items": [
+      {
+        "job": "Tiptronic Gearbox Oil",
+        "interval": "96k miles",
+        "price": "£305",
+        "service_category": "Transmission",
+        "service_item": "Tiptronic Gearbox Oil",
+        "interval_miles": "96000",
+        "interval_years": "",
+        "raw_price": "305"
+      }
+    ]
+  },
+  {
+    "id": "911-964-964-c2-c4-1989-1993",
+    "title": "911 (964) — C2 / C4 (1989–1993)",
     "model_family": "911",
     "generation": "964",
-    "variants": [
+    "variant": "964 C2 / C4",
+    "years": "1989–1993",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "911-964",
+    "model_title": "911 (964)",
+    "items": [
       {
-        "name": "964 C2 / C4",
-        "heading": "C2 / C4 (1989–1993)",
-        "years": "1989–1993",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Service",
-            "interval": "6k miles",
-            "price": "£255",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "6000",
-            "interval_years": "",
-            "raw_price": "255"
-          },
-          {
-            "job": "Service",
-            "interval": "12k miles",
-            "price": "£640",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "640"
-          },
-          {
-            "job": "Service (C2)",
-            "interval": "24k miles",
-            "price": "£245",
-            "service_category": "Other",
-            "service_item": "Service (C2)",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "245"
-          },
-          {
-            "job": "Service (C4)",
-            "interval": "24k miles",
-            "price": "£245",
-            "service_category": "Other",
-            "service_item": "Service (C4)",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "245"
-          },
-          {
-            "job": "Service (C2)",
-            "interval": "48k miles",
-            "price": "£340",
-            "service_category": "Other",
-            "service_item": "Service (C2)",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "340"
-          },
-          {
-            "job": "Service (C4)",
-            "interval": "48k miles",
-            "price": "£370",
-            "service_category": "Other",
-            "service_item": "Service (C4)",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "370"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Service",
+        "interval": "6k miles",
+        "price": "£255",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "6000",
+        "interval_years": "",
+        "raw_price": "255"
       },
       {
-        "name": "964 Turbo / RS",
-        "heading": "Turbo / RS (1989–1993, Petrol (Turbo))",
-        "years": "1989–1993",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Service",
-            "interval": "6k miles",
-            "price": "£350",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "6000",
-            "interval_years": "",
-            "raw_price": "350"
-          },
-          {
-            "job": "Service",
-            "interval": "12k miles",
-            "price": "£745",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "745"
-          },
-          {
-            "job": "Service",
-            "interval": "24k miles",
-            "price": "£1055",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "1055"
-          },
-          {
-            "job": "Service",
-            "interval": "48k miles",
-            "price": "£1145",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "1145"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Service",
+        "interval": "12k miles",
+        "price": "£640",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "640"
+      },
+      {
+        "job": "Service (C2)",
+        "interval": "24k miles",
+        "price": "£245",
+        "service_category": "Other",
+        "service_item": "Service (C2)",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "245"
+      },
+      {
+        "job": "Service (C4)",
+        "interval": "24k miles",
+        "price": "£245",
+        "service_category": "Other",
+        "service_item": "Service (C4)",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "245"
+      },
+      {
+        "job": "Service (C2)",
+        "interval": "48k miles",
+        "price": "£340",
+        "service_category": "Other",
+        "service_item": "Service (C2)",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "340"
+      },
+      {
+        "job": "Service (C4)",
+        "interval": "48k miles",
+        "price": "£370",
+        "service_category": "Other",
+        "service_item": "Service (C4)",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "370"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "911-993",
-    "title": "911 (993)",
+    "id": "911-964-964-turbo-rs-1989-1993-petrol-turbo",
+    "title": "911 (964) — Turbo / RS (1989–1993, Petrol (Turbo))",
+    "model_family": "911",
+    "generation": "964",
+    "variant": "964 Turbo / RS",
+    "years": "1989–1993",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "",
+    "model_slug": "911-964",
+    "model_title": "911 (964)",
+    "items": [
+      {
+        "job": "Service",
+        "interval": "6k miles",
+        "price": "£350",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "6000",
+        "interval_years": "",
+        "raw_price": "350"
+      },
+      {
+        "job": "Service",
+        "interval": "12k miles",
+        "price": "£745",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "745"
+      },
+      {
+        "job": "Service",
+        "interval": "24k miles",
+        "price": "£1055",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "1055"
+      },
+      {
+        "job": "Service",
+        "interval": "48k miles",
+        "price": "£1145",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "1145"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "911-993-993-c2-c4-1994-1997",
+    "title": "911 (993) — C2 / C4 (1994–1997)",
     "model_family": "911",
     "generation": "993",
-    "variants": [
+    "variant": "993 C2 / C4",
+    "years": "1994–1997",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "911-993",
+    "model_title": "911 (993)",
+    "items": [
       {
-        "name": "993 C2 / C4",
-        "heading": "C2 / C4 (1994–1997)",
-        "years": "1994–1997",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Service",
-            "interval": "6k miles",
-            "price": "£255",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "6000",
-            "interval_years": "",
-            "raw_price": "255"
-          },
-          {
-            "job": "Service",
-            "interval": "12k miles",
-            "price": "£565",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "565"
-          },
-          {
-            "job": "Service",
-            "interval": "24k miles",
-            "price": "£925",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "925"
-          },
-          {
-            "job": "Service (C2)",
-            "interval": "48k miles",
-            "price": "£975",
-            "service_category": "Other",
-            "service_item": "Service (C2)",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "975"
-          },
-          {
-            "job": "Service (C4)",
-            "interval": "48k miles",
-            "price": "£980",
-            "service_category": "Other",
-            "service_item": "Service (C4)",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "980"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Service",
+        "interval": "6k miles",
+        "price": "£255",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "6000",
+        "interval_years": "",
+        "raw_price": "255"
       },
       {
-        "name": "993 Turbo / S / GT2",
-        "heading": "Turbo / S / GT2 (1995–1997, Petrol (Turbo))",
-        "years": "1995–1997",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Service",
-            "interval": "6k miles",
-            "price": "£340",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "6000",
-            "interval_years": "",
-            "raw_price": "340"
-          },
-          {
-            "job": "Service",
-            "interval": "12k miles",
-            "price": "£670",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "670"
-          },
-          {
-            "job": "Service",
-            "interval": "24k miles",
-            "price": "£1065",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "1065"
-          },
-          {
-            "job": "Service",
-            "interval": "48k miles",
-            "price": "£1235",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "1235"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Service",
+        "interval": "12k miles",
+        "price": "£565",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "565"
+      },
+      {
+        "job": "Service",
+        "interval": "24k miles",
+        "price": "£925",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "925"
+      },
+      {
+        "job": "Service (C2)",
+        "interval": "48k miles",
+        "price": "£975",
+        "service_category": "Other",
+        "service_item": "Service (C2)",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "975"
+      },
+      {
+        "job": "Service (C4)",
+        "interval": "48k miles",
+        "price": "£980",
+        "service_category": "Other",
+        "service_item": "Service (C4)",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "980"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "911-1964-1989",
-    "title": "911 (1964–1989)",
+    "id": "911-993-993-turbo-s-gt2-1995-1997-petrol-turbo",
+    "title": "911 (993) — Turbo / S / GT2 (1995–1997, Petrol (Turbo))",
+    "model_family": "911",
+    "generation": "993",
+    "variant": "993 Turbo / S / GT2",
+    "years": "1995–1997",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "",
+    "model_slug": "911-993",
+    "model_title": "911 (993)",
+    "items": [
+      {
+        "job": "Service",
+        "interval": "6k miles",
+        "price": "£340",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "6000",
+        "interval_years": "",
+        "raw_price": "340"
+      },
+      {
+        "job": "Service",
+        "interval": "12k miles",
+        "price": "£670",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "670"
+      },
+      {
+        "job": "Service",
+        "interval": "24k miles",
+        "price": "£1065",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "1065"
+      },
+      {
+        "job": "Service",
+        "interval": "48k miles",
+        "price": "£1235",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "1235"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
+      }
+    ]
+  },
+  {
+    "id": "911-1964-1989-early-911-1964-1989",
+    "title": "911 (1964–1989) — Early 911 (1964–1989)",
     "model_family": "911",
     "generation": "1964–1989",
-    "variants": [
+    "variant": "Early 911",
+    "years": "1964–1989",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "911-1964-1989",
+    "model_title": "911 (1964–1989)",
+    "items": [
       {
-        "name": "Early 911",
-        "heading": "Early 911 (1964–1989)",
-        "years": "1964–1989",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Service",
-            "interval": "6k miles",
-            "price": "£240",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "6000",
-            "interval_years": "",
-            "raw_price": "240"
-          },
-          {
-            "job": "Service",
-            "interval": "12k miles",
-            "price": "£585",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "585"
-          },
-          {
-            "job": "Service",
-            "interval": "24k miles",
-            "price": "£615",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "615"
-          },
-          {
-            "job": "Service",
-            "interval": "48k miles",
-            "price": "£1080",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "1080"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Service",
+        "interval": "6k miles",
+        "price": "£240",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "6000",
+        "interval_years": "",
+        "raw_price": "240"
+      },
+      {
+        "job": "Service",
+        "interval": "12k miles",
+        "price": "£585",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "585"
+      },
+      {
+        "job": "Service",
+        "interval": "24k miles",
+        "price": "£615",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "615"
+      },
+      {
+        "job": "Service",
+        "interval": "48k miles",
+        "price": "£1080",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "1080"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "911-930",
-    "title": "911 (930)",
+    "id": "911-930-930-turbo-1975-1977-petrol-turbo",
+    "title": "911 (930) — Turbo (1975–1977, Petrol (Turbo))",
     "model_family": "911",
     "generation": "930",
-    "variants": [
+    "variant": "930 Turbo",
+    "years": "1975–1977",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "",
+    "model_slug": "911-930",
+    "model_title": "911 (930)",
+    "items": [
       {
-        "name": "930 Turbo",
-        "heading": "Turbo (1975–1977, Petrol (Turbo))",
-        "years": "1975–1977",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Service",
-            "interval": "6k miles",
-            "price": "£280",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "6000",
-            "interval_years": "",
-            "raw_price": "280"
-          },
-          {
-            "job": "Service",
-            "interval": "12k miles",
-            "price": "£755",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "755"
-          },
-          {
-            "job": "Service",
-            "interval": "24k miles",
-            "price": "£815",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "815"
-          },
-          {
-            "job": "Service",
-            "interval": "48k miles",
-            "price": "£1480",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "1480"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Service",
+        "interval": "6k miles",
+        "price": "£280",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "6000",
+        "interval_years": "",
+        "raw_price": "280"
+      },
+      {
+        "job": "Service",
+        "interval": "12k miles",
+        "price": "£755",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "755"
+      },
+      {
+        "job": "Service",
+        "interval": "24k miles",
+        "price": "£815",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "815"
+      },
+      {
+        "job": "Service",
+        "interval": "48k miles",
+        "price": "£1480",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "1480"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "944-8v",
+    "id": "944-8v-8v",
     "title": "944 8V",
     "model_family": "944",
     "generation": "8V",
-    "variants": [
+    "variant": "8V",
+    "years": "",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "944-8v",
+    "model_title": "944 8V",
+    "items": [
       {
-        "name": "8V",
-        "heading": "",
-        "years": "",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Service",
-            "interval": "6k miles",
-            "price": "£190",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "6000",
-            "interval_years": "",
-            "raw_price": "190"
-          },
-          {
-            "job": "Service",
-            "interval": "12k miles",
-            "price": "£305",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "305"
-          },
-          {
-            "job": "Service",
-            "interval": "24k miles",
-            "price": "£330",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "330"
-          },
-          {
-            "job": "Service",
-            "interval": "48k miles",
-            "price": "£605",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "605"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Service",
+        "interval": "6k miles",
+        "price": "£190",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "6000",
+        "interval_years": "",
+        "raw_price": "190"
+      },
+      {
+        "job": "Service",
+        "interval": "12k miles",
+        "price": "£305",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "305"
+      },
+      {
+        "job": "Service",
+        "interval": "24k miles",
+        "price": "£330",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "330"
+      },
+      {
+        "job": "Service",
+        "interval": "48k miles",
+        "price": "£605",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "605"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "944-turbo",
-    "title": "944 Turbo",
+    "id": "944-turbo-turbo-petrol-turbo",
+    "title": "944 Turbo — Petrol (Turbo)",
     "model_family": "944",
     "generation": "Turbo",
-    "variants": [
+    "variant": "Turbo",
+    "years": "",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "",
+    "model_slug": "944-turbo",
+    "model_title": "944 Turbo",
+    "items": [
       {
-        "name": "Turbo",
-        "heading": "Petrol (Turbo)",
-        "years": "",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Service",
-            "interval": "6k miles",
-            "price": "£190",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "6000",
-            "interval_years": "",
-            "raw_price": "190"
-          },
-          {
-            "job": "Service",
-            "interval": "12k miles",
-            "price": "£305",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "305"
-          },
-          {
-            "job": "Service",
-            "interval": "24k miles",
-            "price": "£350",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "350"
-          },
-          {
-            "job": "Service",
-            "interval": "48k miles",
-            "price": "£640",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "640"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Service",
+        "interval": "6k miles",
+        "price": "£190",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "6000",
+        "interval_years": "",
+        "raw_price": "190"
+      },
+      {
+        "job": "Service",
+        "interval": "12k miles",
+        "price": "£305",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "305"
+      },
+      {
+        "job": "Service",
+        "interval": "24k miles",
+        "price": "£350",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "350"
+      },
+      {
+        "job": "Service",
+        "interval": "48k miles",
+        "price": "£640",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "640"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "944-s2-16v",
+    "id": "944-s2-16v-s2-16v",
     "title": "944 S2 16V",
     "model_family": "944",
     "generation": "S2 16V",
-    "variants": [
+    "variant": "S2 16V",
+    "years": "",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "944-s2-16v",
+    "model_title": "944 S2 16V",
+    "items": [
       {
-        "name": "S2 16V",
-        "heading": "",
-        "years": "",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Service",
-            "interval": "6k miles",
-            "price": "£190",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "6000",
-            "interval_years": "",
-            "raw_price": "190"
-          },
-          {
-            "job": "Service",
-            "interval": "12k miles",
-            "price": "£330",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "330"
-          },
-          {
-            "job": "Service",
-            "interval": "24k miles",
-            "price": "£375",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "375"
-          },
-          {
-            "job": "Service",
-            "interval": "48k miles",
-            "price": "£645",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "645"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Service",
+        "interval": "6k miles",
+        "price": "£190",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "6000",
+        "interval_years": "",
+        "raw_price": "190"
+      },
+      {
+        "job": "Service",
+        "interval": "12k miles",
+        "price": "£330",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "330"
+      },
+      {
+        "job": "Service",
+        "interval": "24k miles",
+        "price": "£375",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "375"
+      },
+      {
+        "job": "Service",
+        "interval": "48k miles",
+        "price": "£645",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "645"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "928-8v",
+    "id": "928-8v-8v",
     "title": "928 8V",
     "model_family": "928",
     "generation": "8V",
-    "variants": [
+    "variant": "8V",
+    "years": "",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "928-8v",
+    "model_title": "928 8V",
+    "items": [
       {
-        "name": "8V",
-        "heading": "",
-        "years": "",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Service",
-            "interval": "6k miles",
-            "price": "£210",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "6000",
-            "interval_years": "",
-            "raw_price": "210"
-          },
-          {
-            "job": "Service",
-            "interval": "12k miles",
-            "price": "£450",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "450"
-          },
-          {
-            "job": "Service",
-            "interval": "24k miles",
-            "price": "£495",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "495"
-          },
-          {
-            "job": "Service",
-            "interval": "48k miles",
-            "price": "£610",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "610"
-          },
-          {
-            "job": "Service",
-            "interval": "60k miles",
-            "price": "£895",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "895"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Service",
+        "interval": "6k miles",
+        "price": "£210",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "6000",
+        "interval_years": "",
+        "raw_price": "210"
+      },
+      {
+        "job": "Service",
+        "interval": "12k miles",
+        "price": "£450",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "450"
+      },
+      {
+        "job": "Service",
+        "interval": "24k miles",
+        "price": "£495",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "495"
+      },
+      {
+        "job": "Service",
+        "interval": "48k miles",
+        "price": "£610",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "610"
+      },
+      {
+        "job": "Service",
+        "interval": "60k miles",
+        "price": "£895",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "895"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "928-s4-gt-gts",
+    "id": "928-s4-gt-gts-s4-gt-gts",
     "title": "928 S4 / GT / GTS",
     "model_family": "928",
     "generation": "S4 / GT / GTS",
-    "variants": [
+    "variant": "S4 / GT / GTS",
+    "years": "",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "928-s4-gt-gts",
+    "model_title": "928 S4 / GT / GTS",
+    "items": [
       {
-        "name": "S4 / GT / GTS",
-        "heading": "",
-        "years": "",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Service",
-            "interval": "6k miles",
-            "price": "£210",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "6000",
-            "interval_years": "",
-            "raw_price": "210"
-          },
-          {
-            "job": "Service",
-            "interval": "12k miles",
-            "price": "£450",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "450"
-          },
-          {
-            "job": "Service",
-            "interval": "24k miles",
-            "price": "£495",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "495"
-          },
-          {
-            "job": "Service",
-            "interval": "48k miles",
-            "price": "£610",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "610"
-          },
-          {
-            "job": "Service",
-            "interval": "60k miles",
-            "price": "£865",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "60000",
-            "interval_years": "",
-            "raw_price": "865"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Service",
+        "interval": "6k miles",
+        "price": "£210",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "6000",
+        "interval_years": "",
+        "raw_price": "210"
+      },
+      {
+        "job": "Service",
+        "interval": "12k miles",
+        "price": "£450",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "450"
+      },
+      {
+        "job": "Service",
+        "interval": "24k miles",
+        "price": "£495",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "495"
+      },
+      {
+        "job": "Service",
+        "interval": "48k miles",
+        "price": "£610",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "610"
+      },
+      {
+        "job": "Service",
+        "interval": "60k miles",
+        "price": "£865",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "60000",
+        "interval_years": "",
+        "raw_price": "865"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "968-1992-1993",
-    "title": "968 (1992–1993)",
+    "id": "968-1992-1993-base-1992-1993",
+    "title": "968 (1992–1993) — Base (1992–1993)",
     "model_family": "968",
     "generation": "1992–1993",
-    "variants": [
+    "variant": "Base",
+    "years": "1992–1993",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "968-1992-1993",
+    "model_title": "968 (1992–1993)",
+    "items": [
       {
-        "name": "Base",
-        "heading": "Base (1992–1993)",
-        "years": "1992–1993",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Service",
-            "interval": "6k miles",
-            "price": "£190",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "6000",
-            "interval_years": "",
-            "raw_price": "190"
-          },
-          {
-            "job": "Service",
-            "interval": "12k miles",
-            "price": "£280",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "280"
-          },
-          {
-            "job": "Service",
-            "interval": "24k miles",
-            "price": "£355",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "355"
-          },
-          {
-            "job": "Service",
-            "interval": "48k miles",
-            "price": "£645",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "645"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Service",
+        "interval": "6k miles",
+        "price": "£190",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "6000",
+        "interval_years": "",
+        "raw_price": "190"
+      },
+      {
+        "job": "Service",
+        "interval": "12k miles",
+        "price": "£280",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "280"
+      },
+      {
+        "job": "Service",
+        "interval": "24k miles",
+        "price": "£355",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "355"
+      },
+      {
+        "job": "Service",
+        "interval": "48k miles",
+        "price": "£645",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "645"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "968-tiptronic",
-    "title": "968 Tiptronic",
+    "id": "968-tiptronic-tiptronic-tiptronic",
+    "title": "968 Tiptronic — Tiptronic",
     "model_family": "968",
     "generation": "Tiptronic",
-    "variants": [
+    "variant": "Tiptronic",
+    "years": "",
+    "powertrain": "",
+    "transmission": "Tiptronic",
+    "model_slug": "968-tiptronic",
+    "model_title": "968 Tiptronic",
+    "items": [
       {
-        "name": "Tiptronic",
-        "heading": "Tiptronic",
-        "years": "",
-        "powertrain": "",
-        "transmission": "Tiptronic",
-        "items": [
-          {
-            "job": "Service",
-            "interval": "6k miles",
-            "price": "£190",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "6000",
-            "interval_years": "",
-            "raw_price": "190"
-          },
-          {
-            "job": "Service",
-            "interval": "12k miles",
-            "price": "£280",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "280"
-          },
-          {
-            "job": "Service",
-            "interval": "24k miles",
-            "price": "£450",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "450"
-          },
-          {
-            "job": "Service",
-            "interval": "48k miles",
-            "price": "£840",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "840"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Service",
+        "interval": "6k miles",
+        "price": "£190",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "6000",
+        "interval_years": "",
+        "raw_price": "190"
+      },
+      {
+        "job": "Service",
+        "interval": "12k miles",
+        "price": "£280",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "280"
+      },
+      {
+        "job": "Service",
+        "interval": "24k miles",
+        "price": "£450",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "450"
+      },
+      {
+        "job": "Service",
+        "interval": "48k miles",
+        "price": "£840",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "840"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "968-1994-1995",
-    "title": "968 (1994–1995)",
+    "id": "968-1994-1995-base-1994-1995",
+    "title": "968 (1994–1995) — Base (1994–1995)",
     "model_family": "968",
     "generation": "1994–1995",
-    "variants": [
+    "variant": "Base",
+    "years": "1994–1995",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "968-1994-1995",
+    "model_title": "968 (1994–1995)",
+    "items": [
       {
-        "name": "Base",
-        "heading": "Base (1994–1995)",
-        "years": "1994–1995",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Service",
-            "interval": "6k miles",
-            "price": "£190",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "6000",
-            "interval_years": "",
-            "raw_price": "190"
-          },
-          {
-            "job": "Service",
-            "interval": "12k miles",
-            "price": "£280",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "280"
-          },
-          {
-            "job": "Service",
-            "interval": "24k miles",
-            "price": "£450",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "450"
-          },
-          {
-            "job": "Service",
-            "interval": "48k miles",
-            "price": "£750",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "750"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Service",
+        "interval": "6k miles",
+        "price": "£190",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "6000",
+        "interval_years": "",
+        "raw_price": "190"
+      },
+      {
+        "job": "Service",
+        "interval": "12k miles",
+        "price": "£280",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "280"
+      },
+      {
+        "job": "Service",
+        "interval": "24k miles",
+        "price": "£450",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "450"
+      },
+      {
+        "job": "Service",
+        "interval": "48k miles",
+        "price": "£750",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "750"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "924-base",
+    "id": "924-base-base",
     "title": "924 Base",
     "model_family": "924",
     "generation": "Base",
-    "variants": [
+    "variant": "Base",
+    "years": "",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "924-base",
+    "model_title": "924 Base",
+    "items": [
       {
-        "name": "Base",
-        "heading": "",
-        "years": "",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Service",
-            "interval": "6k miles",
-            "price": "£190",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "6000",
-            "interval_years": "",
-            "raw_price": "190"
-          },
-          {
-            "job": "Service",
-            "interval": "12k miles",
-            "price": "£305",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "305"
-          },
-          {
-            "job": "Service",
-            "interval": "24k miles",
-            "price": "£330",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "330"
-          },
-          {
-            "job": "Service",
-            "interval": "48k miles",
-            "price": "£640",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "640"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Service",
+        "interval": "6k miles",
+        "price": "£190",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "6000",
+        "interval_years": "",
+        "raw_price": "190"
+      },
+      {
+        "job": "Service",
+        "interval": "12k miles",
+        "price": "£305",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "305"
+      },
+      {
+        "job": "Service",
+        "interval": "24k miles",
+        "price": "£330",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "330"
+      },
+      {
+        "job": "Service",
+        "interval": "48k miles",
+        "price": "£640",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "640"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "924-turbo-gt-gts",
-    "title": "924 Turbo / GT / GTS",
+    "id": "924-turbo-gt-gts-turbo-gt-gts-petrol-turbo",
+    "title": "924 Turbo / GT / GTS — Petrol (Turbo)",
     "model_family": "924",
     "generation": "Turbo / GT / GTS",
-    "variants": [
+    "variant": "Turbo / GT / GTS",
+    "years": "",
+    "powertrain": "Petrol (Turbo)",
+    "transmission": "",
+    "model_slug": "924-turbo-gt-gts",
+    "model_title": "924 Turbo / GT / GTS",
+    "items": [
       {
-        "name": "Turbo / GT / GTS",
-        "heading": "Petrol (Turbo)",
-        "years": "",
-        "powertrain": "Petrol (Turbo)",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Service",
-            "interval": "6k miles",
-            "price": "£190",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "6000",
-            "interval_years": "",
-            "raw_price": "190"
-          },
-          {
-            "job": "Service",
-            "interval": "12k miles",
-            "price": "£305",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "305"
-          },
-          {
-            "job": "Service",
-            "interval": "24k miles",
-            "price": "£350",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "350"
-          },
-          {
-            "job": "Service",
-            "interval": "48k miles",
-            "price": "£620",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "620"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Service",
+        "interval": "6k miles",
+        "price": "£190",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "6000",
+        "interval_years": "",
+        "raw_price": "190"
+      },
+      {
+        "job": "Service",
+        "interval": "12k miles",
+        "price": "£305",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "305"
+      },
+      {
+        "job": "Service",
+        "interval": "24k miles",
+        "price": "£350",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "350"
+      },
+      {
+        "job": "Service",
+        "interval": "48k miles",
+        "price": "£620",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "620"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
       }
     ]
   },
   {
-    "id": "924-924",
-    "title": "924",
+    "id": "924-924-924-s",
+    "title": "924 — S",
     "model_family": "924",
     "generation": "924",
-    "variants": [
+    "variant": "924 S",
+    "years": "",
+    "powertrain": "",
+    "transmission": "",
+    "model_slug": "924-924",
+    "model_title": "924",
+    "items": [
       {
-        "name": "924 S",
-        "heading": "S",
-        "years": "",
-        "powertrain": "",
-        "transmission": "",
-        "items": [
-          {
-            "job": "Service",
-            "interval": "6k miles",
-            "price": "£190",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "6000",
-            "interval_years": "",
-            "raw_price": "190"
-          },
-          {
-            "job": "Service",
-            "interval": "12k miles",
-            "price": "£305",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "12000",
-            "interval_years": "",
-            "raw_price": "305"
-          },
-          {
-            "job": "Service",
-            "interval": "24k miles",
-            "price": "£330",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "24000",
-            "interval_years": "",
-            "raw_price": "330"
-          },
-          {
-            "job": "Service",
-            "interval": "48k miles",
-            "price": "£605",
-            "service_category": "Other",
-            "service_item": "Service",
-            "interval_miles": "48000",
-            "interval_years": "",
-            "raw_price": "605"
-          },
-          {
-            "job": "Brake Fluid Change",
-            "interval": "—",
-            "price": "£95",
-            "service_category": "Fluids",
-            "service_item": "Brake Fluid",
-            "interval_miles": "",
-            "interval_years": "",
-            "raw_price": "95"
-          }
-        ]
+        "job": "Service",
+        "interval": "6k miles",
+        "price": "£190",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "6000",
+        "interval_years": "",
+        "raw_price": "190"
+      },
+      {
+        "job": "Service",
+        "interval": "12k miles",
+        "price": "£305",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "12000",
+        "interval_years": "",
+        "raw_price": "305"
+      },
+      {
+        "job": "Service",
+        "interval": "24k miles",
+        "price": "£330",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "24000",
+        "interval_years": "",
+        "raw_price": "330"
+      },
+      {
+        "job": "Service",
+        "interval": "48k miles",
+        "price": "£605",
+        "service_category": "Other",
+        "service_item": "Service",
+        "interval_miles": "48000",
+        "interval_years": "",
+        "raw_price": "605"
+      },
+      {
+        "job": "Brake Fluid Change",
+        "interval": "—",
+        "price": "£95",
+        "service_category": "Fluids",
+        "service_item": "Brake Fluid",
+        "interval_miles": "",
+        "interval_years": "",
+        "raw_price": "95"
       }
     ]
   }


### PR DESCRIPTION
## Summary
- flatten the price list generation to produce one section per unique model/variant/powertrain combination
- ensure rendered tables use full headings and expose model aliases for filtering
- update the exported JSON payload to match the new flattened structure

## Testing
- SHEET_CSV_URL="file:///tmp/prices.csv" python scripts/build_prices.py

------
https://chatgpt.com/codex/tasks/task_e_68cc167ba7208324b1234899f0d293f4