### PR TITLE
Fix scheduled price update workflow permissions

### DIFF
--- a/.github/workflows/site-pipeline.yml
+++ b/.github/workflows/site-pipeline.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
   pages: write
   id-token: write
 


### PR DESCRIPTION
## Summary
- grant the workflow permission to manage pull requests so nightly runs can open update PRs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db88334c7c8324beea78eae30103e8